### PR TITLE
Add formatted_street to address

### DIFF
--- a/lib/geocodio/address.rb
+++ b/lib/geocodio/address.rb
@@ -5,7 +5,8 @@ require 'geocodio/timezone'
 
 module Geocodio
   class Address
-    attr_reader :number, :predirectional, :street, :suffix, :city, :state, :zip, :county
+    attr_reader :number, :predirectional, :street, :formatted_street, :suffix,
+                :city, :state, :zip, :county
 
     attr_reader :latitude, :longitude
     alias :lat :latitude
@@ -41,14 +42,15 @@ module Geocodio
     private
 
     def set_attributes(attributes)
-      @number         = attributes['number']
-      @predirectional = attributes['predirectional']
-      @street         = attributes['street']
-      @suffix         = attributes['suffix']
-      @city           = attributes['city']
-      @state          = attributes['state']
-      @zip            = attributes['zip']
-      @county         = attributes['county']
+      @number           = attributes['number']
+      @predirectional   = attributes['predirectional']
+      @street           = attributes['street']
+      @formatted_street = attributes['formatted_street']
+      @suffix           = attributes['suffix']
+      @city             = attributes['city']
+      @state            = attributes['state']
+      @zip              = attributes['zip']
+      @county           = attributes['county']
     end
 
     def set_coordinates(coordinates)

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -21,6 +21,10 @@ describe Geocodio::Address do
     it 'has a street' do
       expect(address.street).to eq('Colorado')
     end
+    
+    it 'has a formatted_street' do
+      expect(address.formatted_street).to eq('W Colorado Blvd')
+    end
 
     it 'has a suffix' do
       expect(address.suffix).to eq('Blvd')
@@ -70,6 +74,10 @@ describe Geocodio::Address do
 
     it 'has a street' do
       expect(address.street).to eq('Colorado')
+    end
+    
+    it 'has a formatted_street' do
+      expect(address.formatted_street).to eq('W Colorado Blvd')
     end
 
     it 'has a suffix' do


### PR DESCRIPTION
Adding formatted street for those who want to store the formatted street in their database. The advantage here is that you don't need to assemble a street with the following attributes:

- number
- predirectional
- street_name
- postdirectional
- suffix