### PR TITLE
Add postdirectional to address

### DIFF
--- a/lib/geocodio/address.rb
+++ b/lib/geocodio/address.rb
@@ -5,8 +5,8 @@ require 'geocodio/timezone'
 
 module Geocodio
   class Address
-    attr_reader :number, :predirectional, :street, :formatted_street, :suffix,
-                :city, :state, :zip, :county
+    attr_reader :number, :predirectional, :street, :suffix, :postdirectional,
+                :formatted_street, :city, :state, :zip, :county
 
     attr_reader :latitude, :longitude
     alias :lat :latitude
@@ -45,8 +45,9 @@ module Geocodio
       @number           = attributes['number']
       @predirectional   = attributes['predirectional']
       @street           = attributes['street']
-      @formatted_street = attributes['formatted_street']
       @suffix           = attributes['suffix']
+      @postdirectional  = attributes['postdirectional']
+      @formatted_street = attributes['formatted_street']
       @city             = attributes['city']
       @state            = attributes['state']
       @zip              = attributes['zip']

--- a/lib/geocodio/address.rb
+++ b/lib/geocodio/address.rb
@@ -5,7 +5,8 @@ require 'geocodio/timezone'
 
 module Geocodio
   class Address
-    attr_reader :number, :predirectional, :street, :suffix, :city, :state, :zip, :county
+    attr_reader :number, :predirectional, :street, :formatted_street, :suffix,
+                :city, :state, :zip, :county
 
     attr_reader :latitude, :longitude
     alias :lat :latitude
@@ -41,14 +42,15 @@ module Geocodio
     private
 
     def set_attributes(attributes)
-      @number         = attributes['number']
-      @predirectional = attributes['predirectional']
-      @street         = attributes['street']
-      @suffix         = attributes['suffix']
-      @city           = attributes['city']
-      @state          = attributes['state']
-      @zip            = attributes['zip']
-      @county         = attributes['county']
+      @number           = attributes['number']
+      @predirectional   = attributes['predirectional']
+      @street           = attributes['street']
+      @formatted_street = attributes['formatted_street']
+      @suffix           = attributes['suffix']
+      @city             = attributes['city']
+      @state            = attributes['state']
+      @zip              = attributes['zip']
+      @county           = attributes['county']
     end
 
     def set_coordinates(coordinates)

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -58,60 +58,120 @@ describe Geocodio::Address do
   end
 
   context 'when geocoded' do
-    subject(:address) do
-      VCR.use_cassette('geocode') do
-        geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105']).best
+    context 'has predirectional' do
+      subject(:address) do
+        VCR.use_cassette('geocode') do
+          geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105']).best
+        end
+      end
+
+      it 'has a number' do
+        expect(address.number).to eq('54')
+      end
+
+      it 'has a predirectional' do
+        expect(address.predirectional).to eq('W')
+      end
+
+      it 'has a street' do
+        expect(address.street).to eq('Colorado')
+      end
+      
+      it 'has a formatted_street' do
+        expect(address.formatted_street).to eq('W Colorado Blvd')
+      end
+
+      it 'has a suffix' do
+        expect(address.suffix).to eq('Blvd')
+      end
+
+      it 'has a city' do
+        expect(address.city).to eq('Pasadena')
+      end
+
+      it 'has a county' do
+        expect(address.county).to eq('Los Angeles County')
+      end
+
+      it 'has a state' do
+        expect(address.state).to eq('CA')
+      end
+
+      it 'has a zip' do
+        expect(address.zip).to eq('91105')
+      end
+
+      it 'has a latitude' do
+        expect(address.latitude).to eq(34.145764409091)
+        expect(address.lat).to      eq(34.145764409091)
+      end
+
+      it 'has a longitude' do
+        expect(address.longitude).to eq(-118.15159636364)
+        expect(address.lng).to       eq(-118.15159636364)
+      end
+
+      it 'has an accuracy' do
+        expect(address.accuracy).to eq(1)
       end
     end
-
-    it 'has a number' do
-      expect(address.number).to eq('54')
-    end
-
-    it 'has a predirectional' do
-      expect(address.predirectional).to eq('W')
-    end
-
-    it 'has a street' do
-      expect(address.street).to eq('Colorado')
-    end
     
-    it 'has a formatted_street' do
-      expect(address.formatted_street).to eq('W Colorado Blvd')
-    end
+    context 'has postdirectional' do
+      subject(:address) do
+        VCR.use_cassette('geocode_with_postdirectional') do
+          geocodio.geocode(['1600 Pennsylvania Ave NW Washington DC 20500']).best
+        end
+      end
 
-    it 'has a suffix' do
-      expect(address.suffix).to eq('Blvd')
-    end
+      it 'has a number' do
+        expect(address.number).to eq('1600')
+      end
 
-    it 'has a city' do
-      expect(address.city).to eq('Pasadena')
-    end
+      it 'has a street' do
+        expect(address.street).to eq('Pennsylvania')
+      end
+      
+      it 'has a formatted_street' do
+        expect(address.formatted_street).to eq('Pennsylvania Ave NW')
+      end
+      
+      it 'has a postdirectional' do
+        expect(address.postdirectional).to eq('NW')
+      end
 
-    it 'has a county' do
-      expect(address.county).to eq('Los Angeles County')
-    end
+      it 'has a suffix' do
+        expect(address.suffix).to eq('Ave')
+      end
 
-    it 'has a state' do
-      expect(address.state).to eq('CA')
-    end
+      it 'has a city' do
+        expect(address.city).to eq('Washington')
+      end
 
-    it 'has a zip' do
-      expect(address.zip).to eq('91105')
-    end
+      it 'has a county' do
+        expect(address.county).to eq('District of Columbia')
+      end
 
-    it 'has a latitude' do
-      expect(address.latitude).to eq(34.145764409091)
-      expect(address.lat).to      eq(34.145764409091)
-    end
+      it 'has a state' do
+        expect(address.state).to eq('DC')
+      end
 
-    it 'has a longitude' do
-      expect(address.longitude).to eq(-118.15159636364)
-      expect(address.lng).to       eq(-118.15159636364)
-    end
+      it 'has a zip' do
+        expect(address.zip).to eq('20500')
+      end
 
-    it 'has an accuracy' do
-      expect(address.accuracy).to eq(1)
+      it 'has a latitude' do
+        expect(address.latitude).to eq(38.897667)
+        expect(address.lat).to      eq(38.897667)
+      end
+
+      it 'has a longitude' do
+        expect(address.longitude).to eq(-77.036545)
+        expect(address.lng).to       eq(-77.036545)
+      end
+
+      it 'has an accuracy' do
+        expect(address.accuracy).to eq(1)
+      end
     end
 
     context 'with additional fields' do

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -21,6 +21,10 @@ describe Geocodio::Address do
     it 'has a street' do
       expect(address.street).to eq('Colorado')
     end
+    
+    it 'has a formatted_street' do
+      expect(address.formatted_street).to eq('W Colorado Blvd')
+    end
 
     it 'has a suffix' do
       expect(address.suffix).to eq('Blvd')
@@ -70,6 +74,10 @@ describe Geocodio::Address do
 
     it 'has a street' do
       expect(address.street).to eq('Colorado')
+    end
+    
+    it 'has a formatted_street' do
+      expect(address.formatted_street).to eq('W Colorado Blvd')
     end
 
     it 'has a suffix' do

--- a/spec/vcr_cassettes/geocode_with_postdirectional.yml
+++ b/spec/vcr_cassettes/geocode_with_postdirectional.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.geocod.io/v1/geocode?api_key=secret_api_key&q=1600%20Pennsylvania%20Ave%20NW%20Washington%20DC%2020500
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.2
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Cache-Control:
+      - no-cache
+      Date:
+      - Mon, 26 Dec 2016 21:50:06 GMT
+      Request-Handler:
+      - api17
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST
+      Access-Control-Allow-Headers:
+      - Content-Type
+    body:
+      encoding: ASCII-8BIT
+      string: '{"input":{"address_components":{"number":"1600","street":"Pennsylvania","suffix":"Ave","postdirectional":"NW","formatted_street":"Pennsylvania
+        Ave NW","city":"Washington","state":"DC","zip":"20500","country":"US"},"formatted_address":"1600
+        Pennsylvania Ave NW, Washington, DC 20500"},"results":[{"address_components":{"number":"1600","street":"Pennsylvania","suffix":"Ave","postdirectional":"NW","formatted_street":"Pennsylvania
+        Ave NW","city":"Washington","county":"District of Columbia","state":"DC","zip":"20500","country":"US"},"formatted_address":"1600
+        Pennsylvania Ave NW, Washington, DC 20500","location":{"lat":38.897667,"lng":-77.036545},"accuracy":1,"accuracy_type":"rooftop","source":"DC
+        Geographic Information Systems Program (DC GIS)"}]}'
+    http_version: 
+  recorded_at: Mon, 26 Dec 2016 21:50:06 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Adding postdirectional to geocode when addresses have a postdirectional. This seems to happen a lot with DC streets in my experience.