### PR TITLE
Added nil check for school districts

### DIFF
--- a/lib/geocodio/address.rb
+++ b/lib/geocodio/address.rb
@@ -85,8 +85,8 @@ module Geocodio
       if schools['unified']
         @unified_school_district = SchoolDistrict.new(schools['unified'])
       else
-        @elementary_school_district = SchoolDistrict.new(schools['elementary'])
-        @secondary_school_district = SchoolDistrict.new(schools['secondary'])
+        @elementary_school_district = SchoolDistrict.new(schools['elementary']) if schools['elementary']
+        @secondary_school_district = SchoolDistrict.new(schools['secondary']) if schools['secondary']
       end
     end
 


### PR DESCRIPTION
Geocoding an address such as `"PO BOX 1827, SOLEDAD, CA 93960"` resulted in the error `NoMethodError: undefined method `[]' for nil:NilClass` because one of the results had an elementary school district but not a secondary school district.

Solution is to simply add a nil check before building a `SchoolDistrict`.