### PR TITLE
Update Geocode API to 1.7, Canadian and OCD IDs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Geocodio [![Build Status](https://travis-ci.org/davidcelis/geocodio.png?branch=master)](https://travis-ci.org/davidcelis/geocodio) [![Coverage Status](https://coveralls.io/repos/davidcelis/geocodio/badge.png)](https://coveralls.io/r/davidcelis/geocodio) [![Code Climate](https://codeclimate.com/github/davidcelis/geocodio.png)](https://codeclimate.com/github/davidcelis/geocodio)
 
-Geocodio is a lightweight Ruby wrapper around the [geocod.io][geocod.io] API.
+Geocodio is a lightweight Ruby wrapper around the [geocod.io][geocod.io] API for [`versions >= 1.7`](https://www.geocod.io/docs/#v1-7).
 
 ## Installation
 
@@ -94,10 +94,10 @@ Note that this endpoint performs no geocoding; it merely formats a single provid
 
 ### Additional fields
 
-Geocodio has added support for retrieving [additional fields][fields] when geocoding or reverse geocoding. To request these fields, pass an options hash to either `#geocode` or `#reverse_geocode`. Possible fields include `cd` or `cd113`, `stateleg`, `school`, and `timezone`:
+Geocodio has added support for retrieving [additional fields][fields] when geocoding or reverse geocoding. To request these fields, pass an options hash to either `#geocode` or `#reverse_geocode`. Possible fields include or `cd113`,( or `cd` to get current legislators), `stateleg`, `stateleg-next`, `school`, and `timezone`, [Open Civic Data Division Identifiers (OCD-IDs)](https://www.geocod.io/docs/#ocd-identifiers) `cd118` and `stateleg-next` are required.
 
 ```ruby
-address = geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd stateleg school timezone]).best
+address = geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd118 stateleg-next school timezone]).best
 
 address.congressional_districts
 # => #<Geocodio::CongressionalDistrict:0x007fa3c15f41c0 @name="Congressional District 27" @district_number=27 @congress_number=113 @congress_years=2013..2015>
@@ -116,6 +116,34 @@ address.timezone
 address.timezone.observes_dst?
 # => true
 ```
+
+#### Canadian address
+
+To fetch Canadian federal and provincial electoral districts, include to [`provriding` and `riding`](https://www.geocod.io/docs/#riding-canadian-provincial-electoral-district) to the  `fields` input. From the result, check if the Canadian data is available by method `Address#canadian?` then it's `true`, get the districts data from method `Address#canadian` as following:
+
+```ruby
+address = geocodio.geocode(['160 Spadina Ave., Toronto, ON M5T 2C2, Canada'], 
+  fields: %w[cd118 stateleg-next school timezone]).best
+
+address.canadian?
+# => true
+
+address.canadian.federal_electoral_district
+# => #<Geocodio::Canadian::FederalElectoralDistrict:0x00007f9c173ff358
+#  @code="35101",
+#  @name_english="Spadina--Fort York",
+#  @name_french="Spadina--Fort York",
+#  @ocd_id="ocd-division/country:ca/ed:35101-2013",
+#  @source="Statistics Canada">
+
+address.canadian.provincial_electoral_district
+#<Geocodio::Canadian::ProvincialElectoralDistrict:0x00007fd9001046a0
+#  @name_english="University - Rosedale",
+#  @name_french="University - Rosedale",
+#  @ocd_id="ocd-division/country:ca/province:on/ed:112-2015",
+#  @source="Elections Ontario">
+```
+
 
 ## Contributing
 

--- a/lib/geocodio.rb
+++ b/lib/geocodio.rb
@@ -1,6 +1,7 @@
 require 'geocodio/address'
 require 'geocodio/address_set'
 require 'geocodio/client'
+require 'geocodio/canadian'
 
 require 'geocodio/version'
 

--- a/lib/geocodio/address.rb
+++ b/lib/geocodio/address.rb
@@ -23,13 +23,14 @@ module Geocodio
     # How accurate geocod.io deemed this result to be given the original query.
     #
     # @return [Float] a number between 0 and 1
-    attr_reader :accuracy, :accuracy_type
+    attr_reader :accuracy, :accuracy_type, :source
 
     def initialize(payload = {})
       set_attributes(payload['address_components']) if payload['address_components']
       set_coordinates(payload['location'])          if payload['location']
       set_additional_fields(payload['fields'])      if payload['fields']
 
+      @source            = payload['source']
       @accuracy          = payload['accuracy']
       @accuracy_type     = payload['accuracy_type']
       @formatted_address = payload['formatted_address']

--- a/lib/geocodio/address.rb
+++ b/lib/geocodio/address.rb
@@ -14,7 +14,7 @@ module Geocodio
     alias :lat :latitude
     alias :lng :longitude
 
-    attr_reader :congressional_districts, :house_district, :senate_district,
+    attr_reader :congressional_districts, :house_districts, :senate_districts,
                 :unified_school_district, :elementary_school_district,
                 :secondary_school_district
 
@@ -83,9 +83,9 @@ module Geocodio
 
     def set_legislative_districts(districts)
       return if districts.empty?
-      house, senate = districts.values_at('house', 'senate').map(&:first)
-      @house_district = StateLegislativeDistrict.new(house) if house
-      @senate_district = StateLegislativeDistrict.new(senate) if senate
+      @house_districts, @senate_districts = districts.values_at('house', 'senate').map do |district_entries|
+        [*district_entries].map{|entry|  StateLegislativeDistrict.new(entry)}
+      end
     end
 
     def set_school_districts(schools)

--- a/lib/geocodio/canadian.rb
+++ b/lib/geocodio/canadian.rb
@@ -1,0 +1,14 @@
+module Geocodio
+  module Canadian
+    attr_reader :canadian
+    
+    def set_canadian_fields(riding, provincial_riding)
+      @canadian = ElectoralDistricts.new(riding, provincial_riding)
+    end
+
+    def canadian?
+      !!@canadian
+    end
+
+  end
+end

--- a/lib/geocodio/canadian/electoral_district_base.rb
+++ b/lib/geocodio/canadian/electoral_district_base.rb
@@ -1,0 +1,21 @@
+module Geocodio
+  module Canadian
+    class ElectoralDistrictBase
+      attr_accessor :ocd_id
+      attr_accessor :name_french
+      attr_accessor :name_english
+      attr_accessor :source
+
+      def initialize(payload = {})
+        @ocd_id          = payload['ocd_id']
+        @name_english    = payload['name_english']
+        @name_french     = payload['name_french']
+        @source          = payload['source']
+      end
+
+      def name
+        @name_english
+      end
+    end
+  end
+end

--- a/lib/geocodio/canadian/electoral_districts.rb
+++ b/lib/geocodio/canadian/electoral_districts.rb
@@ -1,0 +1,23 @@
+require 'geocodio/canadian/electoral_district_base'
+require 'geocodio/canadian/federal_electoral_district'
+require 'geocodio/canadian/provincial_electoral_district'
+
+module Geocodio
+  module Canadian
+    class ElectoralDistricts
+      attr_accessor :federal_electoral_district
+      attr_accessor :provincial_electoral_district
+      
+      def initialize(riding, provincial_riding)
+
+        if riding && riding.is_a?(Hash) && riding.size > 0
+          @federal_electoral_district = FederalElectoralDistrict.new(riding)
+        end
+        
+        if provincial_riding && provincial_riding.is_a?(Hash) && provincial_riding.size > 0
+          @provincial_electoral_district = ProvincialElectoralDistrict.new(provincial_riding)
+        end
+      end
+    end
+  end
+end

--- a/lib/geocodio/canadian/federal_electoral_district.rb
+++ b/lib/geocodio/canadian/federal_electoral_district.rb
@@ -1,0 +1,12 @@
+module Geocodio
+  module Canadian
+    class FederalElectoralDistrict < ElectoralDistrictBase
+      attr_accessor :code
+      
+      def initialize(payload = {})
+        super
+        @code = payload['code']
+      end
+    end
+  end
+end

--- a/lib/geocodio/canadian/provincial_electoral_district.rb
+++ b/lib/geocodio/canadian/provincial_electoral_district.rb
@@ -1,0 +1,6 @@
+module Geocodio
+  module Canadian
+    class ProvincialElectoralDistrict < ElectoralDistrictBase
+    end
+  end
+end

--- a/lib/geocodio/client.rb
+++ b/lib/geocodio/client.rb
@@ -18,7 +18,7 @@ module Geocodio
       :delete => Net::HTTP::Delete
     }
     HOST = 'api.geocod.io'
-    BASE_PATH = '/v1.2'
+    BASE_PATH = '/v1.7'
     PORT = 80
 
     def initialize(api_key = ENV['GEOCODIO_API_KEY'])
@@ -133,14 +133,13 @@ module Geocodio
           q = params.map { |k, v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}" }
           path += "&#{q.join('&')}"
         end
-
+        
         req = METHODS[method].new(BASE_PATH + path, 'Accept' => CONTENT_TYPE)
 
         if options.key?(:body)
           req['Content-Type'] = CONTENT_TYPE
           req.body = options[:body] ? JSON.dump(options[:body]) : ''
-        end
-
+        end     
         http = Net::HTTP.new HOST, PORT
         http.read_timeout = options[:timeout] if options[:timeout]
         res  = http.start { http.request(req) }

--- a/lib/geocodio/congressional_district.rb
+++ b/lib/geocodio/congressional_district.rb
@@ -7,6 +7,7 @@ module Geocodio
     attr_reader :congress_number
     attr_reader :proportion
     attr_reader :current_legislators
+    attr_accessor :ocd_id
 
     def initialize(payload = {})
       @name            = payload['name']
@@ -14,8 +15,9 @@ module Geocodio
       @congress_number = payload['congress_number'].to_i
       @congress_years  = payload['congress_years']
       @proportion      = payload['proportion'].to_i
-
-      @current_legislators = payload['current_legislators'].map do |legislator|
+      @ocd_id          = payload['ocd_id']
+      
+      @current_legislators = [*payload['current_legislators']].map do |legislator|
         Legislator.new(legislator)
       end
     end

--- a/lib/geocodio/state_legislative_district.rb
+++ b/lib/geocodio/state_legislative_district.rb
@@ -2,11 +2,15 @@ module Geocodio
   class StateLegislativeDistrict
     attr_accessor :name
     attr_accessor :district_number
+    attr_accessor :proportion
+    attr_accessor :ocd_id
 
     def initialize(payload = {})
       @name            = payload['name']
       @district_number = payload['district_number'].to_i
       @district_number = payload['district_number'] if @district_number == 0
+      @proportion      = payload['proportion']
+      @ocd_id          = payload['ocd_id']
     end
   end
 end

--- a/lib/geocodio/version.rb
+++ b/lib/geocodio/version.rb
@@ -1,6 +1,6 @@
 module Geocodio
   class Version
-    MAJOR = 3
+    MAJOR = 4
     MINOR = 0
     PATCH = 0
 

--- a/spec/address_set_spec.rb
+++ b/spec/address_set_spec.rb
@@ -17,7 +17,7 @@ describe Geocodio::AddressSet do
   end
 
   it 'has a size' do
-    expect(address_set.size).to eq(2)
+    expect(address_set.size).to eq(4)
   end
 
   it 'has a best' do

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Geocodio::Address do
   let(:geocodio) { Geocodio::Client.new }
-
+  
   context 'when parsed' do
     subject(:address) do
       VCR.use_cassette('parse') do
@@ -189,7 +189,7 @@ describe Geocodio::Address do
     context 'with additional fields' do
       subject(:address) do
         VCR.use_cassette('geocode_with_fields') do
-          geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd stateleg school timezone]).best
+          geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd118 stateleg-next school timezone]).best
         end
       end
 

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -122,6 +122,10 @@ describe Geocodio::Address do
       it 'has an accuracy_type' do
         expect(address.accuracy_type).to eq("rooftop")
       end
+      
+      it 'has a source' do
+        expect(address.source).to eq("Los Angeles")
+      end
     end
 
     context 'has postdirectional' do

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -203,12 +203,16 @@ describe Geocodio::Address do
         end
       end
 
-      it 'has a house district' do
-        expect(address.house_district).to be_a(Geocodio::StateLegislativeDistrict)
+      it 'has house districts' do
+        expect(address.house_districts).to be_a(Array)
+        expect(address.house_districts.size).to eq(1)
+        expect(address.house_districts.first).to be_a(Geocodio::StateLegislativeDistrict)
       end
 
-      it 'has a senate district' do
-        expect(address.senate_district).to be_a(Geocodio::StateLegislativeDistrict)
+      it 'has senate districts' do
+        expect(address.senate_districts).to be_a(Array)
+        expect(address.senate_districts.size).to eq(1)
+        expect(address.senate_districts.first).to be_a(Geocodio::StateLegislativeDistrict)
       end
 
       it 'has a unified school district' do

--- a/spec/canadian_spec.rb
+++ b/spec/canadian_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe Geocodio::Canadian do
+  let(:geocodio) { Geocodio::Client.new }
+  
+  subject do
+    VCR.use_cassette('canadian') do
+      geocodio.geocode([
+        '1 Infinite Loop Cupertino CA 95014',
+        '356 Yonge St, Toronto, ON M5G, Canada',
+        '3475 Bd Sainte-Anne, Beauport, QC G1E 3L5, Canada'
+      ], fields: %w[timezone cd118 provriding riding stateleg-next]).map(&:best)
+    end
+  end
+
+  let(:us_address)   { subject[0] }
+  let(:ca_en_address){ subject[1] }
+  let(:ca_fr_address){ subject[2] }
+
+  it 'is a canadian address' do
+    expect(ca_en_address).to be_canadian
+    expect(ca_fr_address).to be_canadian
+  end
+  
+  it "isn't a canadian address" do
+    expect(us_address).to_not be_canadian
+    expect(us_address.canadian).to be_nil
+  end
+  
+  it 'has canadian federal electoral district' do
+    expect(ca_en_address.canadian).to_not be_nil
+    expect(ca_en_address.canadian.federal_electoral_district).to_not be_nil
+    
+    federal_district1 = ca_en_address.canadian.federal_electoral_district
+    
+    expect(federal_district1.code).to eq('35110')
+    expect(federal_district1.name_english).to eq('University--Rosedale')
+    expect(federal_district1.name_french).to eq('University--Rosedale')
+    expect(federal_district1.ocd_id).to eq('ocd-division/country:ca/ed:35110-2013')
+    expect(federal_district1.source).to eq('Statistics Canada')
+    
+    expect(ca_fr_address.canadian).to_not be_nil
+    expect(ca_fr_address.canadian.federal_electoral_district).to_not be_nil
+    
+    federal_district2 = ca_fr_address.canadian.federal_electoral_district
+    
+    expect(federal_district2.code).to eq('24008')
+    expect(federal_district2.name_english).to eq('Beauport--Limoilou')
+    expect(federal_district2.name_french).to eq('Beauport--Limoilou')
+    expect(federal_district2.ocd_id).to eq('ocd-division/country:ca/ed:24008-2013')
+    expect(federal_district2.source).to eq('Statistics Canada')    
+  end
+  
+  it 'has canadian provincial electoral district' do
+    expect(ca_en_address.canadian).to_not be_nil
+    expect(ca_en_address.canadian.provincial_electoral_district).to_not be_nil
+    
+    provincial_district1 = ca_en_address.canadian.provincial_electoral_district
+    
+    expect(provincial_district1.name_english).to eq('University - Rosedale')
+    expect(provincial_district1.name_french).to eq('University - Rosedale')
+    expect(provincial_district1.ocd_id).to eq('ocd-division/country:ca/province:on/ed:112-2015')
+    expect(provincial_district1.source).to eq('Elections Ontario')
+    
+    expect(ca_fr_address.canadian).to_not be_nil
+    expect(ca_fr_address.canadian.provincial_electoral_district).to_not be_nil
+    
+    provincial_district2 = ca_fr_address.canadian.provincial_electoral_district
+    
+    expect(provincial_district2.name_english).to eq('Montmorency')
+    expect(provincial_district2.name_french).to eq('Montmorency')
+    expect(provincial_district2.ocd_id).to eq('ocd-division/country:ca/province:qc/ed:742-2017')
+    expect(provincial_district2.source).to eq("Contains open data granted under the Chief Electoral Officer's Open Data User Licence available at http://dgeq.org/en/. The fact of granting the licence in no way implies that the Chief Electoral Officer approves the use made of the open data.")    
+  end
+
+  
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -36,7 +36,7 @@ describe Geocodio::Client do
 
     it 'geocodes a single address with an options hash' do
       VCR.use_cassette('geocode_with_fields') do
-        addresses = geocodio.geocode([address], fields: %w[cd stateleg school timezone])
+        addresses = geocodio.geocode([address], fields: %w[cd118 stateleg-next school timezone])
 
         expect(addresses.size).to eq(2)
         expect(addresses).to be_a(Geocodio::AddressSet)
@@ -85,7 +85,7 @@ describe Geocodio::Client do
           '826 Howard Street San Francisco CA 94103'
         ]
 
-        addresses = geocodio.geocode(addresses, fields: %w[cd stateleg school timezone])
+        addresses = geocodio.geocode(addresses, fields: %w[cd118 stateleg-next school timezone])
 
         expect(addresses.size).to eq(3)
         addresses.each { |address| expect(address).to be_a(Geocodio::AddressSet) }
@@ -99,14 +99,14 @@ describe Geocodio::Client do
         VCR.use_cassette('reverse') do
           addresses = geocodio.reverse_geocode([coordinates])
 
-          expect(addresses.size).to eq(5)
+          expect(addresses.size).to eq(13)
           expect(addresses).to be_a(Geocodio::AddressSet)
         end
       end
 
       it 'handles a response without legislator house info' do
         VCR.use_cassette('reverse_with_fields_no_house_info') do
-          expect { geocodio.reverse_geocode(["41.25,-96.00"], fields: %w[cd stateleg school timezone]) }.not_to raise_error(NoMethodError)
+          expect { geocodio.reverse_geocode(["41.25,-96.00"], fields: %w[cd118 stateleg-next school timezone]) }.not_to raise_error(NoMethodError)
         end
       end
 
@@ -115,7 +115,7 @@ describe Geocodio::Client do
           lat, lng = coordinates.split(',')
           addresses = geocodio.reverse_geocode([{ latitude: lat, longitude: lng }])
 
-          expect(addresses.size).to eq(5)
+          expect(addresses.size).to eq(13)
           expect(addresses).to be_a(Geocodio::AddressSet)
         end
       end
@@ -123,9 +123,9 @@ describe Geocodio::Client do
       it 'accepts an options hash' do
         VCR.use_cassette('reverse_with_fields') do
           lat, lng = coordinates.split(',')
-          addresses = geocodio.reverse_geocode([{ latitude: lat, longitude: lng} ], fields: %w[cd stateleg school timezone])
+          addresses = geocodio.reverse_geocode([{ latitude: lat, longitude: lng} ], fields: %w[cd118 stateleg-next school timezone])
 
-          expect(addresses.size).to eq(5)
+          expect(addresses.size).to eq(13)
           expect(addresses).to be_a(Geocodio::AddressSet)
         end
       end
@@ -185,7 +185,7 @@ describe Geocodio::Client do
             { latitude: 37.7815,   longitude: -122.404933 }
           ]
 
-          addresses = geocodio.reverse_geocode(coordinate_pairs, fields: %w[cd stateleg school timezone])
+          addresses = geocodio.reverse_geocode(coordinate_pairs, fields: %w[cd118 stateleg-next school timezone])
 
           expect(addresses.size).to eq(3)
           addresses.each { |address| expect(address).to be_a(Geocodio::AddressSet) }

--- a/spec/congressional_district_spec.rb
+++ b/spec/congressional_district_spec.rb
@@ -5,7 +5,7 @@ describe Geocodio::CongressionalDistrict do
 
   subject(:district) do
     VCR.use_cassette('geocode_with_fields') do
-      geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd stateleg school timezone]).
+      geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd118 stateleg-next school timezone]).
         best.
         congressional_districts.
         first
@@ -13,23 +13,27 @@ describe Geocodio::CongressionalDistrict do
   end
 
   it 'has a name' do
-    expect(district.name).to eq("Congressional District 27")
+    expect(district.name).to eq("Congressional District 28")
   end
 
   it 'has a district_number' do
-    expect(district.district_number).to eq(27)
+    expect(district.district_number).to eq(28)
   end
 
   it 'has a congress_number' do
-    expect(district.congress_number).to eq(115)
+    expect(district.congress_number).to eq(118)
   end
 
   it 'has a congress_years' do
-    expect(district.congress_years).to eq(2017..2019)
+    expect(district.congress_years).to eq(2023..2025)
   end
 
   it 'has a proportion' do
     expect(district.proportion).to eq(1)
+  end
+
+  it 'has ocd_id' do
+    expect(district.ocd_id).to eq('ocd-division/country:us/state:ca/cd:28')
   end
 
 

--- a/spec/legislator_spec.rb
+++ b/spec/legislator_spec.rb
@@ -4,8 +4,8 @@ describe Geocodio::Legislator do
   let(:geocodio) { Geocodio::Client.new }
 
   subject(:legislator) do
-    VCR.use_cassette('geocode_with_fields') do
-      geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd stateleg school timezone]).
+    VCR.use_cassette('geocode_with_fields_legacy') do
+      geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd stateleg-next school timezone]).
         best.
         congressional_districts.
         first.
@@ -39,7 +39,7 @@ describe Geocodio::Legislator do
   end
 
   it 'has a address' do
-    expect(legislator.address).to eq('2423 Rayburn HOB; Washington DC 20515-0527')
+    expect(legislator.address).to eq('2423 Rayburn House Office Building Washington DC 20515-0527')
   end
 
   it 'has a phone' do

--- a/spec/school_district_spec.rb
+++ b/spec/school_district_spec.rb
@@ -5,7 +5,7 @@ describe Geocodio::SchoolDistrict do
 
   subject(:district) do
     VCR.use_cassette('geocode_with_fields') do
-      geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd stateleg school timezone]).best.unified_school_district
+      geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd118 stateleg-next school timezone]).best.unified_school_district
     end
   end
 

--- a/spec/state_legislative_district_spec.rb
+++ b/spec/state_legislative_district_spec.rb
@@ -6,7 +6,7 @@ describe Geocodio::StateLegislativeDistrict do
   context 'typical numeric district' do
     subject(:district) do
       VCR.use_cassette('geocode_with_fields') do
-        geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd stateleg school timezone]).best.house_district
+        geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd118 stateleg-next school timezone]).best.house_district
       end
     end
 

--- a/spec/state_legislative_district_spec.rb
+++ b/spec/state_legislative_district_spec.rb
@@ -6,7 +6,10 @@ describe Geocodio::StateLegislativeDistrict do
   context 'typical numeric district' do
     subject(:district) do
       VCR.use_cassette('geocode_with_fields') do
-        geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd118 stateleg-next school timezone]).best.house_district
+        geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd118 stateleg-next school timezone])
+          .best
+          .house_districts
+          .first
       end
     end
 
@@ -22,7 +25,10 @@ describe Geocodio::StateLegislativeDistrict do
   context 'Alaska non-numeric state district' do
     subject(:alaska_district) do
       VCR.use_cassette('alaska_geocode_with_fields') do
-        geocodio.geocode(['4141 woronzof dr anchorage ak 99517'], fields: %w[cd stateleg]).best.senate_district
+        geocodio.geocode(['4141 woronzof dr anchorage ak 99517'], fields: %w[cd stateleg])
+          .best
+          .senate_districts
+          .first
       end
     end
 

--- a/spec/timezone_spec.rb
+++ b/spec/timezone_spec.rb
@@ -5,12 +5,12 @@ describe Geocodio::Timezone do
 
   subject(:timezone) do
     VCR.use_cassette('geocode_with_fields') do
-      geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd stateleg school timezone]).best.timezone
+      geocodio.geocode(['54 West Colorado Boulevard Pasadena CA 91105'], fields: %w[cd118 stateleg-next school timezone]).best.timezone
     end
   end
 
   it 'has a name' do
-    expect(timezone.name).to eq('PST')
+    expect(timezone.name).to eq('America/Los_Angeles')
   end
 
   it 'has a utc_offset' do

--- a/spec/vcr_cassettes/alaska_geocode_with_fields.yml
+++ b/spec/vcr_cassettes/alaska_geocode_with_fields.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.geocod.io/v1.2/geocode?api_key=secret_api_key&fields=cd,stateleg&q=4141%20woronzof%20dr%20anchorage%20ak%2099517
+    uri: http://api.geocod.io/v1.7/geocode?api_key=secret_api_key&fields=cd,stateleg&q=4141%20woronzof%20dr%20anchorage%20ak%2099517
     body:
       encoding: US-ASCII
       string: ''
@@ -18,49 +18,51 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 17:35:09 GMT
-      Request-Handler:
-      - api19
+      - Tue, 05 Jul 2022 22:21:48 GMT
+      X-Billable-Lookups-Count:
+      - '1'
+      X-Billable-Fields-Count:
+      - '2'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
       Access-Control-Expose-Headers:
       - Request-Handler
+      Request-Handler:
+      - api245
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FE04_05A15419:0050_62C4B97C_54777:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
       string: '{"input":{"address_components":{"number":"4141","street":"Woronzof","suffix":"Dr","formatted_street":"Woronzof
         Dr","city":"Anchorage","state":"AK","zip":"99517","country":"US"},"formatted_address":"4141
         Woronzof Dr, Anchorage, AK 99517"},"results":[{"address_components":{"number":"4141","street":"Woronzof","suffix":"Dr","formatted_street":"Woronzof
         Dr","city":"Anchorage","county":"Anchorage Municipality","state":"AK","zip":"99517","country":"US"},"formatted_address":"4141
-        Woronzof Dr, Anchorage, AK 99517","location":{"lat":61.193733,"lng":-149.959449},"accuracy":0.8,"accuracy_type":"range_interpolation","source":"TIGER\/Line\u00ae
-        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
-        District (at Large)","district_number":0,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Young","first_name":"Don","birthday":"1933-06-09","gender":"M","party":"Republican"},"contact":{"url":"https:\/\/donyoung.house.gov","address":"2314
-        Rayburn HOB; Washington DC 20515-0200","phone":"202-225-5765","contact_form":null},"social":{"rss_url":"http:\/\/donyoung.house.gov\/news\/rss.aspx","twitter":"RepDonYoung","facebook":"RepDonYoung","youtube":"RepDonYoung","youtube_id":"UCg5ZIR5-82EbJiNeI1bqT-A"},"references":{"bioguide_id":"Y000033","thomas_id":"01256","opensecrets_id":"N00007999","lis_id":null,"cspan_id":"1897","govtrack_id":"400440","votesmart_id":"26717","ballotpedia_id":"Don
-        Young","washington_post_id":null,"icpsr_id":"14066","wikipedia_id":"Don Young"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Murkowski","first_name":"Lisa","birthday":"1957-05-22","gender":"F","party":"Republican"},"contact":{"url":"https:\/\/www.murkowski.senate.gov","address":"522
+        Woronzof Dr, Anchorage, AK 99517","location":{"lat":61.194138,"lng":-149.962696},"accuracy":1,"accuracy_type":"rooftop","source":"Anchorage","fields":{"congressional_districts":[{"name":"Congressional
+        District (at Large)","district_number":0,"ocd_id":null,"congress_number":"117th","congress_years":"2021-2023","proportion":1,"current_legislators":[{"type":"senator","bio":{"last_name":"Murkowski","first_name":"Lisa","birthday":"1957-05-22","gender":"F","party":"Republican"},"contact":{"url":"https:\/\/www.murkowski.senate.gov","address":"522
         Hart Senate Office Building Washington DC 20510","phone":"202-224-6665","contact_form":"https:\/\/www.murkowski.senate.gov\/public\/index.cfm\/contact"},"social":{"rss_url":"http:\/\/www.murkowski.senate.gov\/public\/?a=rss.feed","twitter":"LisaMurkowski","facebook":"SenLisaMurkowski","youtube":"senatormurkowski","youtube_id":"UCaigku16AErqvD0wRuwGb9A"},"references":{"bioguide_id":"M001153","thomas_id":"01694","opensecrets_id":"N00026050","lis_id":"S288","cspan_id":"1004138","govtrack_id":"300075","votesmart_id":"15841","ballotpedia_id":"Lisa
         Murkowski","washington_post_id":null,"icpsr_id":"40300","wikipedia_id":"Lisa
         Murkowski"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Sullivan","first_name":"Dan","birthday":"1964-11-13","gender":"M","party":"Republican"},"contact":{"url":"https:\/\/www.sullivan.senate.gov","address":"702
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3004","contact_form":"https:\/\/www.sullivan.senate.gov\/contact\/email"},"social":{"rss_url":null,"twitter":"SenDanSullivan","facebook":"SenDanSullivan","youtube":null,"youtube_id":"UC7tXCm8gKlAhTFo2kuf5ylw"},"references":{"bioguide_id":"S001198","thomas_id":"02290","opensecrets_id":"N00035774","lis_id":"S383","cspan_id":"1023262","govtrack_id":"412665","votesmart_id":"114964","ballotpedia_id":null,"washington_post_id":null,"icpsr_id":"41500","wikipedia_id":"Dan
-        Sullivan (American senator)"},"source":"Legislator data is originally collected
-        and aggregated by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District K","district_number":"K"},"house":{"name":"State House District
-        21","district_number":"21"}}}}]}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 17:35:09 GMT
-recorded_with: VCR 4.0.0
+        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Sullivan","first_name":"Dan","birthday":"1964-11-13","gender":"M","party":"Republican"},"contact":{"url":"https:\/\/www.sullivan.senate.gov","address":"302
+        Hart Senate Office Building Washington DC 20510","phone":"202-224-3004","contact_form":"https:\/\/www.sullivan.senate.gov\/contact\/email"},"social":{"rss_url":null,"twitter":"SenDanSullivan","facebook":"SenDanSullivan","youtube":null,"youtube_id":"UC7tXCm8gKlAhTFo2kuf5ylw"},"references":{"bioguide_id":"S001198","thomas_id":"02290","opensecrets_id":"N00035774","lis_id":"S383","cspan_id":"1023262","govtrack_id":"412665","votesmart_id":"114964","ballotpedia_id":"Daniel
+        S. Sullivan","washington_post_id":null,"icpsr_id":"41500","wikipedia_id":"Dan
+        Sullivan (U.S. senator)"},"source":"Legislator data is originally collected
+        and aggregated by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"house":[{"name":"State
+        House District 21","district_number":"21","ocd_id":null,"is_upcoming_state_legislative_district":false,"proportion":1}],"senate":[{"name":"State
+        Senate District K","district_number":"K","ocd_id":null,"is_upcoming_state_legislative_district":false,"proportion":1}]}}}]}'
+  recorded_at: Tue, 05 Jul 2022 22:21:48 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/batch_geocode.yml
+++ b/spec/vcr_cassettes/batch_geocode.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.geocod.io/v1.2/geocode?api_key=secret_api_key
+    uri: http://api.geocod.io/v1.7/geocode?api_key=secret_api_key
     body:
       encoding: UTF-8
       string: '["1 Infinite Loop Cupertino CA 95014","54 West Colorado Boulevard Pasadena
@@ -21,44 +21,49 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 17:35:11 GMT
-      Request-Handler:
-      - api19
+      - Tue, 05 Jul 2022 22:21:42 GMT
+      X-Billable-Lookups-Count:
+      - '3'
+      X-Billable-Fields-Count:
+      - '0'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
       Access-Control-Expose-Headers:
       - Request-Handler
+      Request-Handler:
+      - api228
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FDF6_05A15419:0050_62C4B976_54147:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
       string: '{"results":[{"query":"1 Infinite Loop Cupertino CA 95014","response":{"input":{"address_components":{"number":"1","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
         Loop","city":"Cupertino","state":"CA","zip":"95014","country":"US"},"formatted_address":"1
         Infinite Loop, Cupertino, CA 95014"},"results":[{"address_components":{"number":"1","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
         Loop","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"1
-        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.330689,"lng":-122.02912},"accuracy":1,"accuracy_type":"range_interpolation","source":"TIGER\/Line\u00ae
-        dataset from the US Census Bureau"}]}},{"query":"54 West Colorado Boulevard
-        Pasadena CA 91105","response":{"input":{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.331524,"lng":-122.030231},"accuracy":1,"accuracy_type":"rooftop","source":"City
+        of Cupertino"}]}},{"query":"54 West Colorado Boulevard Pasadena CA 91105","response":{"input":{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
         Colorado Blvd","city":"Pasadena","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
-        W Colorado Blvd, Pasadena, CA 91105"},"results":[{"address_components":{"number":"54","predirectional":"E","street":"Colorado","suffix":"Blvd","formatted_street":"E
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
-        E Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145499,"lng":-118.14932},"accuracy":1,"accuracy_type":"rooftop","source":"Los
-        Angeles"},{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        W Colorado Blvd, Pasadena, CA 91105"},"results":[{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
         Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
         W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145375,"lng":-118.151622},"accuracy":1,"accuracy_type":"rooftop","source":"Los
+        Angeles"},{"address_components":{"number":"54","predirectional":"E","street":"Colorado","suffix":"Blvd","formatted_street":"E
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
+        E Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145499,"lng":-118.14932},"accuracy":0.8,"accuracy_type":"rooftop","source":"Los
         Angeles"}]}},{"query":"826 Howard Street San Francisco CA 94103","response":{"input":{"address_components":{"number":"826","street":"Howard","suffix":"St","formatted_street":"Howard
         St","city":"San Francisco","state":"CA","zip":"94103","country":"US"},"formatted_address":"826
         Howard St, San Francisco, CA 94103"},"results":[{"address_components":{"number":"826","street":"Howard","suffix":"St","formatted_street":"Howard
@@ -66,8 +71,13 @@ http_interactions:
         Howard St, San Francisco, CA 94103","location":{"lat":37.782681,"lng":-122.40325},"accuracy":1,"accuracy_type":"range_interpolation","source":"TIGER\/Line\u00ae
         dataset from the US Census Bureau"},{"address_components":{"number":"826","street":"Howard","suffix":"St","formatted_street":"Howard
         St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"826
-        Howard St, San Francisco, CA 94103","location":{"lat":37.782672,"lng":-122.403196},"accuracy":0.8,"accuracy_type":"range_interpolation","source":"TIGER\/Line\u00ae
-        dataset from the US Census Bureau"}]}}]}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 17:35:11 GMT
-recorded_with: VCR 4.0.0
+        Howard St, San Francisco, CA 94103","location":{"lat":37.782672,"lng":-122.403196},"accuracy":0.9,"accuracy_type":"range_interpolation","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"825","street":"Howard","suffix":"St","formatted_street":"Howard
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"825
+        Howard St, San Francisco, CA 94103","location":{"lat":37.782177,"lng":-122.402758},"accuracy":0.9,"accuracy_type":"nearest_rooftop_match","source":"San
+        Francisco"},{"address_components":{"number":"800","street":"Howard","suffix":"St","formatted_street":"Howard
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"800
+        Howard St, San Francisco, CA 94103","location":{"lat":37.783251,"lng":-122.403286},"accuracy":0.85,"accuracy_type":"nearest_rooftop_match","source":"San
+        Francisco"}]}}]}'
+  recorded_at: Tue, 05 Jul 2022 22:21:42 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/batch_geocode_with_bad_address.yml
+++ b/spec/vcr_cassettes/batch_geocode_with_bad_address.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.geocod.io/v1.2/geocode?api_key=secret_api_key
+    uri: http://api.geocod.io/v1.7/geocode?api_key=secret_api_key
     body:
       encoding: UTF-8
       string: '["1 Infinite Loop Cupertino CA 95014"," , , "]'
@@ -20,37 +20,42 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 17:35:12 GMT
-      Request-Handler:
-      - api19
+      - Tue, 05 Jul 2022 22:21:43 GMT
+      X-Billable-Lookups-Count:
+      - '1'
+      X-Billable-Fields-Count:
+      - '0'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
       Access-Control-Expose-Headers:
       - Request-Handler
+      Request-Handler:
+      - api245
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FDFB_05A15419:0050_62C4B977_5423D:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
       string: '{"results":[{"query":"1 Infinite Loop Cupertino CA 95014","response":{"input":{"address_components":{"number":"1","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
         Loop","city":"Cupertino","state":"CA","zip":"95014","country":"US"},"formatted_address":"1
         Infinite Loop, Cupertino, CA 95014"},"results":[{"address_components":{"number":"1","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
         Loop","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"1
-        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.330689,"lng":-122.02912},"accuracy":1,"accuracy_type":"range_interpolation","source":"TIGER\/Line\u00ae
-        dataset from the US Census Bureau"}]}},{"query":" , , ","response":{"error":"Could
-        not geocode address. Postal code or city required.","results":[]}}]}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 17:35:12 GMT
-recorded_with: VCR 4.0.0
+        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.331524,"lng":-122.030231},"accuracy":1,"accuracy_type":"rooftop","source":"City
+        of Cupertino"}]}},{"query":" , , ","response":{"error":"Could not geocode
+        address. Postal code or city required.","results":[]}}]}'
+  recorded_at: Tue, 05 Jul 2022 22:21:43 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/batch_geocode_with_fields.yml
+++ b/spec/vcr_cassettes/batch_geocode_with_fields.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.geocod.io/v1.2/geocode?api_key=secret_api_key&fields=cd,stateleg,school,timezone
+    uri: http://api.geocod.io/v1.7/geocode?api_key=secret_api_key&fields=cd118,stateleg-next,school,timezone
     body:
       encoding: UTF-8
       string: '["1 Infinite Loop Cupertino CA 95014","54 West Colorado Boulevard Pasadena
@@ -21,132 +21,101 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 17:35:10 GMT
-      Request-Handler:
-      - api19
+      - Tue, 05 Jul 2022 22:21:44 GMT
+      X-Billable-Lookups-Count:
+      - '3'
+      X-Billable-Fields-Count:
+      - '12'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
       Access-Control-Expose-Headers:
       - Request-Handler
+      Request-Handler:
+      - api245
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FDFD_05A15419:0050_62C4B977_542CD:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
       string: '{"results":[{"query":"1 Infinite Loop Cupertino CA 95014","response":{"input":{"address_components":{"number":"1","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
         Loop","city":"Cupertino","state":"CA","zip":"95014","country":"US"},"formatted_address":"1
         Infinite Loop, Cupertino, CA 95014"},"results":[{"address_components":{"number":"1","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
         Loop","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"1
-        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.330689,"lng":-122.02912},"accuracy":1,"accuracy_type":"range_interpolation","source":"TIGER\/Line\u00ae
-        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
-        District 17","district_number":17,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Khanna","first_name":"Ro","birthday":"1976-09-13","gender":"M","party":"Democrat"},"contact":{"url":"https:\/\/khanna.house.gov","address":"513
-        Cannon HOB; Washington DC 20515-0517","phone":"202-225-2631","contact_form":null},"social":{"rss_url":null,"twitter":"RepRoKhanna","facebook":"RepRoKhanna","youtube":null,"youtube_id":"UCr4KOYv1o1oEQhy1jhhm3pQ"},"references":{"bioguide_id":"K000389","thomas_id":null,"opensecrets_id":"N00026427","lis_id":null,"cspan_id":"31129","govtrack_id":"412684","votesmart_id":"29473","ballotpedia_id":null,"washington_post_id":null,"icpsr_id":"21728","wikipedia_id":"Ro
-        Khanna"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 15","district_number":"15"},"house":{"name":"Assembly District
-        28","district_number":"28"}},"school_districts":{"elementary":{"name":"Cupertino
+        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.331524,"lng":-122.030231},"accuracy":1,"accuracy_type":"rooftop","source":"City
+        of Cupertino","fields":{"congressional_districts":[{"name":"Congressional
+        District 17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
         Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
-        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}}]}},{"query":"54
-        West Colorado Boulevard Pasadena CA 91105","response":{"input":{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}}]}},{"query":"54 West Colorado Boulevard Pasadena
+        CA 91105","response":{"input":{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
         Colorado Blvd","city":"Pasadena","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
-        W Colorado Blvd, Pasadena, CA 91105"},"results":[{"address_components":{"number":"54","predirectional":"E","street":"Colorado","suffix":"Blvd","formatted_street":"E
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
-        E Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145499,"lng":-118.14932},"accuracy":1,"accuracy_type":"rooftop","source":"Los
-        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        W Colorado Blvd, Pasadena, CA 91105"},"results":[{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
         Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
         W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145375,"lng":-118.151622},"accuracy":1,"accuracy_type":"rooftop","source":"Los
         Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}}]}},{"query":"826
-        Howard Street San Francisco CA 94103","response":{"input":{"address_components":{"number":"826","street":"Howard","suffix":"St","formatted_street":"Howard
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"54","predirectional":"E","street":"Colorado","suffix":"Blvd","formatted_street":"E
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
+        E Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145499,"lng":-118.14932},"accuracy":0.8,"accuracy_type":"rooftop","source":"Los
+        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}}]}},{"query":"826 Howard Street San Francisco
+        CA 94103","response":{"input":{"address_components":{"number":"826","street":"Howard","suffix":"St","formatted_street":"Howard
         St","city":"San Francisco","state":"CA","zip":"94103","country":"US"},"formatted_address":"826
         Howard St, San Francisco, CA 94103"},"results":[{"address_components":{"number":"826","street":"Howard","suffix":"St","formatted_street":"Howard
         St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"826
         Howard St, San Francisco, CA 94103","location":{"lat":37.782681,"lng":-122.40325},"accuracy":1,"accuracy_type":"range_interpolation","source":"TIGER\/Line\u00ae
         dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
-        District 12","district_number":12,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Pelosi","first_name":"Nancy","birthday":"1940-03-26","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/pelosi.house.gov","address":"233
-        Cannon HOB; Washington DC 20515-0512","phone":"202-225-4965","contact_form":null},"social":{"rss_url":"http:\/\/pelosi.house.gov\/atom.xml","twitter":"NancyPelosi","facebook":"NancyPelosi","youtube":"nancypelosi","youtube_id":"UCxPeEcH0xaCK9nBK98EFhDg"},"references":{"bioguide_id":"P000197","thomas_id":"00905","opensecrets_id":"N00007360","lis_id":null,"cspan_id":"6153","govtrack_id":"400314","votesmart_id":"26732","ballotpedia_id":"Nancy
-        Pelosi","washington_post_id":null,"icpsr_id":"15448","wikipedia_id":"Nancy
-        Pelosi"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 11","district_number":"11"},"house":{"name":"Assembly District
-        17","district_number":"17"}},"school_districts":{"unified":{"name":"San Francisco
-        Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"826","street":"Howard","suffix":"St","formatted_street":"Howard
+        District 11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"826","street":"Howard","suffix":"St","formatted_street":"Howard
         St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"826
-        Howard St, San Francisco, CA 94103","location":{"lat":37.782672,"lng":-122.403196},"accuracy":0.8,"accuracy_type":"range_interpolation","source":"TIGER\/Line\u00ae
+        Howard St, San Francisco, CA 94103","location":{"lat":37.782672,"lng":-122.403196},"accuracy":0.9,"accuracy_type":"range_interpolation","source":"TIGER\/Line\u00ae
         dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
-        District 12","district_number":12,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Pelosi","first_name":"Nancy","birthday":"1940-03-26","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/pelosi.house.gov","address":"233
-        Cannon HOB; Washington DC 20515-0512","phone":"202-225-4965","contact_form":null},"social":{"rss_url":"http:\/\/pelosi.house.gov\/atom.xml","twitter":"NancyPelosi","facebook":"NancyPelosi","youtube":"nancypelosi","youtube_id":"UCxPeEcH0xaCK9nBK98EFhDg"},"references":{"bioguide_id":"P000197","thomas_id":"00905","opensecrets_id":"N00007360","lis_id":null,"cspan_id":"6153","govtrack_id":"400314","votesmart_id":"26732","ballotpedia_id":"Nancy
-        Pelosi","washington_post_id":null,"icpsr_id":"15448","wikipedia_id":"Nancy
-        Pelosi"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 11","district_number":"11"},"house":{"name":"Assembly District
-        17","district_number":"17"}},"school_districts":{"unified":{"name":"San Francisco
-        Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}}]}}]}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 17:35:10 GMT
-recorded_with: VCR 4.0.0
+        District 11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"825","street":"Howard","suffix":"St","formatted_street":"Howard
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"825
+        Howard St, San Francisco, CA 94103","location":{"lat":37.782177,"lng":-122.402758},"accuracy":0.9,"accuracy_type":"nearest_rooftop_match","source":"San
+        Francisco","fields":{"congressional_districts":[{"name":"Congressional District
+        11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"800","street":"Howard","suffix":"St","formatted_street":"Howard
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"800
+        Howard St, San Francisco, CA 94103","location":{"lat":37.783251,"lng":-122.403286},"accuracy":0.85,"accuracy_type":"nearest_rooftop_match","source":"San
+        Francisco","fields":{"congressional_districts":[{"name":"Congressional District
+        11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}}]}}]}'
+  recorded_at: Tue, 05 Jul 2022 22:21:44 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/batch_reverse.yml
+++ b/spec/vcr_cassettes/batch_reverse.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.geocod.io/v1.2/reverse?api_key=secret_api_key
+    uri: http://api.geocod.io/v1.7/reverse?api_key=secret_api_key
     body:
       encoding: UTF-8
       string: '["37.331669,-122.03074","34.145760590909,-118.15204363636","37.7815,-122.404933"]'
@@ -20,80 +20,162 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 17:35:13 GMT
-      Request-Handler:
-      - api35
+      - Tue, 05 Jul 2022 22:21:44 GMT
+      X-Billable-Lookups-Count:
+      - '3'
+      X-Billable-Fields-Count:
+      - '0'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
       Access-Control-Expose-Headers:
       - Request-Handler
+      Request-Handler:
+      - api228
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FDFE_05A15419:0050_62C4B978_5436A:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
-      string: '{"results":[{"query":"37.331669,-122.03074","response":{"results":[{"address_components":{"number":"10700","predirectional":"N","street":"De
-        Anza","suffix":"Blvd","formatted_street":"N De Anza Blvd","city":"Cupertino","county":"Santa
+      string: '{"results":[{"query":"37.331669,-122.03074","response":{"results":[{"address_components":{"number":"10700","street":"DE
+        Anza","suffix":"Blvd","formatted_street":"DE Anza Blvd","city":"Cupertino","county":"Santa
         Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10700
-        N De Anza Blvd, Cupertino, CA 95014","location":{"lat":37.331686,"lng":-122.030223},"accuracy":1,"accuracy_type":"rooftop","source":"Santa
-        Clara County"},{"address_components":{"number":"10690","predirectional":"N","street":"De
-        Anza","suffix":"Blvd","formatted_street":"N De Anza Blvd","city":"Cupertino","county":"Santa
+        DE Anza Blvd, Cupertino, CA 95014","location":{"lat":37.331693,"lng":-122.030057},"accuracy":0.99,"accuracy_type":"rooftop","source":"Santa
+        Clara"},{"address_components":{"number":"10700","predirectional":"N","street":"DE
+        Anza","suffix":"Blvd","formatted_street":"N DE Anza Blvd","city":"Cupertino","county":"Santa
+        Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10700
+        N DE Anza Blvd, Cupertino, CA 95014","location":{"lat":37.331966,"lng":-122.030416},"accuracy":0.98,"accuracy_type":"rooftop","source":"City
+        of Cupertino"},{"address_components":{"number":"1","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
+        Loop","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"1
+        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.331524,"lng":-122.030231},"accuracy":0.98,"accuracy_type":"rooftop","source":"City
+        of Cupertino"},{"address_components":{"number":"10690","predirectional":"N","street":"DE
+        Anza","suffix":"Blvd","formatted_street":"N DE Anza Blvd","city":"Cupertino","county":"Santa
         Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10690
-        N De Anza Blvd, Cupertino, CA 95014","location":{"lat":37.331293,"lng":-122.031735},"accuracy":0.89,"accuracy_type":"rooftop","source":"Santa
-        Clara County"},{"address_components":{"number":"2","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
-        Loop","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"2
-        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.332633,"lng":-122.030273},"accuracy":0.89,"accuracy_type":"rooftop","source":"Santa
-        Clara County"},{"address_components":{"number":"6","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
-        Loop","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"6
-        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.330944,"lng":-122.029633},"accuracy":0.89,"accuracy_type":"rooftop","source":"Santa
-        Clara County"},{"address_components":{"number":"10600","predirectional":"N","street":"De
-        Anza","suffix":"Blvd","formatted_street":"N De Anza Blvd","city":"Cupertino","county":"Santa
-        Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10600
-        N De Anza Blvd, Cupertino, CA 95014","location":{"lat":37.330648,"lng":-122.031701},"accuracy":0.89,"accuracy_type":"rooftop","source":"Santa
-        Clara County"}]}},{"query":"34.145760590909,-118.15204363636","response":{"results":[{"address_components":{"number":"68","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"68
-        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":1,"accuracy_type":"rooftop","source":"Los
+        N DE Anza Blvd, Cupertino, CA 95014","location":{"lat":37.331177,"lng":-122.031641},"accuracy":0.97,"accuracy_type":"rooftop","source":"Santa
+        Clara"},{"address_components":{"number":"10856","predirectional":"N","street":"DE
+        Anza","suffix":"Blvd","formatted_street":"N DE Anza Blvd","city":"Cupertino","county":"Santa
+        Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10856
+        N DE Anza Blvd, Cupertino, CA 95014","location":{"lat":37.33182,"lng":-122.03239},"accuracy":0.94,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"10826","predirectional":"N","street":"DE
+        Anza","suffix":"Blvd","formatted_street":"N DE Anza Blvd","city":"Cupertino","county":"Santa
+        Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10826
+        N DE Anza Blvd, Cupertino, CA 95014","location":{"lat":37.33122,"lng":-122.03238},"accuracy":0.94,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"10748","predirectional":"N","street":"DE
+        Anza","suffix":"Blvd","formatted_street":"N DE Anza Blvd","city":"Cupertino","county":"Santa
+        Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10748
+        N DE Anza Blvd, Cupertino, CA 95014","location":{"lat":37.330219,"lng":-122.03238},"accuracy":0.93,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"91","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
+        Loop","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"91
+        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.332709,"lng":-122.03071},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"19118","street":"Mariani","suffix":"Ave","formatted_street":"Mariani
+        Ave","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"19118
+        Mariani Ave, Cupertino, CA 95014","location":{"lat":37.330489,"lng":-122.0305},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"19479","street":"Mariani","suffix":"Ave","formatted_street":"Mariani
+        Ave","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"19479
+        Mariani Ave, Cupertino, CA 95014","location":{"lat":37.330519,"lng":-122.03008},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"19116","street":"Mariani","suffix":"Ave","formatted_street":"Mariani
+        Ave","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"19116
+        Mariani Ave, Cupertino, CA 95014","location":{"lat":37.330407,"lng":-122.030873},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"20500","street":"Valley
+        Green","suffix":"Dr","formatted_street":"Valley Green Dr","city":"Cupertino","county":"Santa
+        Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"20500
+        Valley Green Dr, Cupertino, CA 95014","location":{"lat":37.33182,"lng":-122.03239},"accuracy":0.42,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"}]}},{"query":"34.145760590909,-118.15204363636","response":{"results":[{"address_components":{"number":"10","predirectional":"S","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"S DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"10
+        S DE Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
         Angeles"},{"address_components":{"number":"58","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
         Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"58
-        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
-        Angeles"},{"address_components":{"number":"60","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"60
-        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
-        Angeles"},{"address_components":{"number":"10","predirectional":"S","street":"De
-        Lacey","suffix":"Ave","formatted_street":"S De Lacey Ave","city":"Pasadena","county":"Los
-        Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"10
-        S De Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
         Angeles"},{"address_components":{"number":"69","street":"Mc Cormick","suffix":"Aly","formatted_street":"Mc
         Cormick Aly","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"69
-        Mc Cormick Aly, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
-        Angeles"}]}},{"query":"37.7815,-122.404933","response":{"results":[{"address_components":{"number":"198","street":"05th","suffix":"St","formatted_street":"05th
-        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"198
-        05th St, San Francisco, CA 94103","location":{"lat":37.781458,"lng":-122.405257},"accuracy":1,"accuracy_type":"rooftop","source":"San
-        Francisco"},{"address_components":{"number":"194","street":"05th","suffix":"St","formatted_street":"05th
-        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"194
-        05th St, San Francisco, CA 94103","location":{"lat":37.781458,"lng":-122.405257},"accuracy":0.9,"accuracy_type":"rooftop","source":"San
-        Francisco"},{"address_components":{"number":"906","street":"Howard","suffix":"St","formatted_street":"Howard
+        Mc Cormick Aly, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
+        Angeles"},{"address_components":{"number":"60","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"60
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
+        Angeles"},{"address_components":{"number":"68","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"68
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
+        Angeles"},{"address_components":{"number":"1","predirectional":"N","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"N DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91103","country":"US"},"formatted_address":"1
+        N DE Lacey Ave, Pasadena, CA 91103","location":{"lat":34.145759,"lng":-118.15223},"accuracy":0.98,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"1","predirectional":"S","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"S DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"1
+        S DE Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145759,"lng":-118.15223},"accuracy":0.98,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"22","predirectional":"S","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"S DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"22
+        S DE Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145407,"lng":-118.152227},"accuracy":0.97,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"25","predirectional":"N","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"N DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91103","country":"US"},"formatted_address":"25
+        N DE Lacey Ave, Pasadena, CA 91103","location":{"lat":34.146409,"lng":-118.152234},"accuracy":0.96,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"85","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"85
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145759,"lng":-118.15223},"accuracy":0.47,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"1","street":"Fraser","suffix":"Aly","formatted_street":"Fraser
+        Aly","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"1
+        Fraser Aly, Pasadena, CA 91105","location":{"lat":34.145407,"lng":-118.152227},"accuracy":0.46,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"43","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"43
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145766,"lng":-118.15141},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"100","street":"Christiansen","suffix":"Aly","formatted_street":"Christiansen
+        Aly","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91103","country":"US"},"formatted_address":"100
+        Christiansen Aly, Pasadena, CA 91103","location":{"lat":34.146409,"lng":-118.152234},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"}]}},{"query":"37.7815,-122.404933","response":{"results":[{"address_components":{"number":"906","street":"Howard","suffix":"St","formatted_street":"Howard
         St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"906
-        Howard St, San Francisco, CA 94103","location":{"lat":37.781458,"lng":-122.405257},"accuracy":0.9,"accuracy_type":"rooftop","source":"San
-        Francisco"},{"address_components":{"number":"206","street":"05th","suffix":"St","formatted_street":"05th
+        Howard St, San Francisco, CA 94103","location":{"lat":37.781471,"lng":-122.405246},"accuracy":1,"accuracy_type":"rooftop","source":"San
+        Francisco"},{"address_components":{"number":"194","street":"5th","suffix":"St","formatted_street":"5th
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"194
+        5th St, San Francisco, CA 94103","location":{"lat":37.781466,"lng":-122.405248},"accuracy":1,"accuracy_type":"rooftop","source":"San
+        Francisco"},{"address_components":{"number":"198","street":"5th","suffix":"St","formatted_street":"5th
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"198
+        5th St, San Francisco, CA 94103","location":{"lat":37.781467,"lng":-122.405249},"accuracy":1,"accuracy_type":"rooftop","source":"San
+        Francisco"},{"address_components":{"number":"206","street":"5th","suffix":"St","formatted_street":"5th
         St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"206
-        05th St, San Francisco, CA 94103","location":{"lat":37.781187,"lng":-122.404925},"accuracy":0.9,"accuracy_type":"rooftop","source":"San
-        Francisco"},{"address_components":{"number":"190","street":"05th","suffix":"St","formatted_street":"05th
-        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"190
-        05th St, San Francisco, CA 94103","location":{"lat":37.781508,"lng":-122.405329},"accuracy":0.9,"accuracy_type":"rooftop","source":"San
-        Francisco"}]}}]}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 17:35:13 GMT
-recorded_with: VCR 4.0.0
+        5th St, San Francisco, CA 94103","location":{"lat":37.781187,"lng":-122.404925},"accuracy":0.99,"accuracy_type":"rooftop","source":"San
+        Francisco"},{"address_components":{"number":"901","street":"Howard","suffix":"St","formatted_street":"Howard
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"901
+        Howard St, San Francisco, CA 94103","location":{"lat":37.781185,"lng":-122.404921},"accuracy":0.99,"accuracy_type":"rooftop","source":"San
+        Francisco"},{"address_components":{"number":"900","street":"Howard","suffix":"St","formatted_street":"Howard
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"900
+        Howard St, San Francisco, CA 94103","location":{"lat":37.7815,"lng":-122.404933},"accuracy":0.5,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"227","street":"5th","suffix":"St","formatted_street":"5th
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"227
+        5th St, San Francisco, CA 94103","location":{"lat":37.781076,"lng":-122.404404},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"400","street":"Tehama","suffix":"St","formatted_street":"Tehama
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"400
+        Tehama St, San Francisco, CA 94103","location":{"lat":37.781076,"lng":-122.404404},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"177","street":"5th","suffix":"St","formatted_street":"5th
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"177
+        5th St, San Francisco, CA 94103","location":{"lat":37.781925,"lng":-122.405466},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"400","street":"Natoma","suffix":"St","formatted_street":"Natoma
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"400
+        Natoma St, San Francisco, CA 94103","location":{"lat":37.781925,"lng":-122.405466},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"928","street":"Howard","suffix":"St","formatted_street":"Howard
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"928
+        Howard St, San Francisco, CA 94103","location":{"lat":37.780878,"lng":-122.405719},"accuracy":0.44,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"80","street":"Mary","suffix":"St","formatted_street":"Mary
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"80
+        Mary St, San Francisco, CA 94103","location":{"lat":37.781306,"lng":-122.406248},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"432","street":"Natoma","suffix":"St","formatted_street":"Natoma
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"432
+        Natoma St, San Francisco, CA 94103","location":{"lat":37.781306,"lng":-122.406248},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"}]}}]}'
+  recorded_at: Tue, 05 Jul 2022 22:21:44 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/batch_reverse_with_fields.yml
+++ b/spec/vcr_cassettes/batch_reverse_with_fields.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.geocod.io/v1.2/reverse?api_key=secret_api_key&fields=cd,stateleg,school,timezone
+    uri: http://api.geocod.io/v1.7/reverse?api_key=secret_api_key&fields=cd118,stateleg-next,school,timezone
     body:
       encoding: UTF-8
       string: '["37.331669,-122.03074","34.145760590909,-118.15204363636","37.7815,-122.404933"]'
@@ -20,316 +20,365 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 17:35:14 GMT
-      Request-Handler:
-      - api19
+      - Tue, 05 Jul 2022 22:21:45 GMT
+      X-Billable-Lookups-Count:
+      - '3'
+      X-Billable-Fields-Count:
+      - '12'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
       Access-Control-Expose-Headers:
       - Request-Handler
+      Request-Handler:
+      - api245
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FDFF_05A15419:0050_62C4B978_543F6:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
-      string: '{"results":[{"query":"37.331669,-122.03074","response":{"results":[{"address_components":{"number":"10700","predirectional":"N","street":"De
-        Anza","suffix":"Blvd","formatted_street":"N De Anza Blvd","city":"Cupertino","county":"Santa
+      string: '{"results":[{"query":"37.331669,-122.03074","response":{"results":[{"address_components":{"number":"10700","street":"DE
+        Anza","suffix":"Blvd","formatted_street":"DE Anza Blvd","city":"Cupertino","county":"Santa
         Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10700
-        N De Anza Blvd, Cupertino, CA 95014","location":{"lat":37.331686,"lng":-122.030223},"accuracy":1,"accuracy_type":"rooftop","source":"Santa
-        Clara County","fields":{"congressional_districts":[{"name":"Congressional
-        District 17","district_number":17,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Khanna","first_name":"Ro","birthday":"1976-09-13","gender":"M","party":"Democrat"},"contact":{"url":"https:\/\/khanna.house.gov","address":"513
-        Cannon HOB; Washington DC 20515-0517","phone":"202-225-2631","contact_form":null},"social":{"rss_url":null,"twitter":"RepRoKhanna","facebook":"RepRoKhanna","youtube":null,"youtube_id":"UCr4KOYv1o1oEQhy1jhhm3pQ"},"references":{"bioguide_id":"K000389","thomas_id":null,"opensecrets_id":"N00026427","lis_id":null,"cspan_id":"31129","govtrack_id":"412684","votesmart_id":"29473","ballotpedia_id":null,"washington_post_id":null,"icpsr_id":"21728","wikipedia_id":"Ro
-        Khanna"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 15","district_number":"15"},"house":{"name":"Assembly District
-        28","district_number":"28"}},"school_districts":{"elementary":{"name":"Cupertino
+        DE Anza Blvd, Cupertino, CA 95014","location":{"lat":37.331693,"lng":-122.030057},"accuracy":0.99,"accuracy_type":"rooftop","source":"Santa
+        Clara","fields":{"congressional_districts":[{"name":"Congressional District
+        17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
         Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
-        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"10690","predirectional":"N","street":"De
-        Anza","suffix":"Blvd","formatted_street":"N De Anza Blvd","city":"Cupertino","county":"Santa
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"10700","predirectional":"N","street":"DE
+        Anza","suffix":"Blvd","formatted_street":"N DE Anza Blvd","city":"Cupertino","county":"Santa
+        Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10700
+        N DE Anza Blvd, Cupertino, CA 95014","location":{"lat":37.331966,"lng":-122.030416},"accuracy":0.98,"accuracy_type":"rooftop","source":"City
+        of Cupertino","fields":{"congressional_districts":[{"name":"Congressional
+        District 17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
+        Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"1","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
+        Loop","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"1
+        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.331524,"lng":-122.030231},"accuracy":0.98,"accuracy_type":"rooftop","source":"City
+        of Cupertino","fields":{"congressional_districts":[{"name":"Congressional
+        District 17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
+        Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"10690","predirectional":"N","street":"DE
+        Anza","suffix":"Blvd","formatted_street":"N DE Anza Blvd","city":"Cupertino","county":"Santa
         Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10690
-        N De Anza Blvd, Cupertino, CA 95014","location":{"lat":37.331293,"lng":-122.031735},"accuracy":0.89,"accuracy_type":"rooftop","source":"Santa
-        Clara County","fields":{"congressional_districts":[{"name":"Congressional
-        District 17","district_number":17,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Khanna","first_name":"Ro","birthday":"1976-09-13","gender":"M","party":"Democrat"},"contact":{"url":"https:\/\/khanna.house.gov","address":"513
-        Cannon HOB; Washington DC 20515-0517","phone":"202-225-2631","contact_form":null},"social":{"rss_url":null,"twitter":"RepRoKhanna","facebook":"RepRoKhanna","youtube":null,"youtube_id":"UCr4KOYv1o1oEQhy1jhhm3pQ"},"references":{"bioguide_id":"K000389","thomas_id":null,"opensecrets_id":"N00026427","lis_id":null,"cspan_id":"31129","govtrack_id":"412684","votesmart_id":"29473","ballotpedia_id":null,"washington_post_id":null,"icpsr_id":"21728","wikipedia_id":"Ro
-        Khanna"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 15","district_number":"15"},"house":{"name":"Assembly District
-        28","district_number":"28"}},"school_districts":{"elementary":{"name":"Cupertino
+        N DE Anza Blvd, Cupertino, CA 95014","location":{"lat":37.331177,"lng":-122.031641},"accuracy":0.97,"accuracy_type":"rooftop","source":"Santa
+        Clara","fields":{"congressional_districts":[{"name":"Congressional District
+        17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
         Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
-        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"2","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
-        Loop","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"2
-        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.332633,"lng":-122.030273},"accuracy":0.89,"accuracy_type":"rooftop","source":"Santa
-        Clara County","fields":{"congressional_districts":[{"name":"Congressional
-        District 17","district_number":17,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Khanna","first_name":"Ro","birthday":"1976-09-13","gender":"M","party":"Democrat"},"contact":{"url":"https:\/\/khanna.house.gov","address":"513
-        Cannon HOB; Washington DC 20515-0517","phone":"202-225-2631","contact_form":null},"social":{"rss_url":null,"twitter":"RepRoKhanna","facebook":"RepRoKhanna","youtube":null,"youtube_id":"UCr4KOYv1o1oEQhy1jhhm3pQ"},"references":{"bioguide_id":"K000389","thomas_id":null,"opensecrets_id":"N00026427","lis_id":null,"cspan_id":"31129","govtrack_id":"412684","votesmart_id":"29473","ballotpedia_id":null,"washington_post_id":null,"icpsr_id":"21728","wikipedia_id":"Ro
-        Khanna"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 15","district_number":"15"},"house":{"name":"Assembly District
-        28","district_number":"28"}},"school_districts":{"elementary":{"name":"Cupertino
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"10856","predirectional":"N","street":"DE
+        Anza","suffix":"Blvd","formatted_street":"N DE Anza Blvd","city":"Cupertino","county":"Santa
+        Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10856
+        N DE Anza Blvd, Cupertino, CA 95014","location":{"lat":37.33182,"lng":-122.03239},"accuracy":0.94,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
         Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
-        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"6","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
-        Loop","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"6
-        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.330944,"lng":-122.029633},"accuracy":0.89,"accuracy_type":"rooftop","source":"Santa
-        Clara County","fields":{"congressional_districts":[{"name":"Congressional
-        District 17","district_number":17,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Khanna","first_name":"Ro","birthday":"1976-09-13","gender":"M","party":"Democrat"},"contact":{"url":"https:\/\/khanna.house.gov","address":"513
-        Cannon HOB; Washington DC 20515-0517","phone":"202-225-2631","contact_form":null},"social":{"rss_url":null,"twitter":"RepRoKhanna","facebook":"RepRoKhanna","youtube":null,"youtube_id":"UCr4KOYv1o1oEQhy1jhhm3pQ"},"references":{"bioguide_id":"K000389","thomas_id":null,"opensecrets_id":"N00026427","lis_id":null,"cspan_id":"31129","govtrack_id":"412684","votesmart_id":"29473","ballotpedia_id":null,"washington_post_id":null,"icpsr_id":"21728","wikipedia_id":"Ro
-        Khanna"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 15","district_number":"15"},"house":{"name":"Assembly District
-        28","district_number":"28"}},"school_districts":{"elementary":{"name":"Cupertino
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"10826","predirectional":"N","street":"DE
+        Anza","suffix":"Blvd","formatted_street":"N DE Anza Blvd","city":"Cupertino","county":"Santa
+        Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10826
+        N DE Anza Blvd, Cupertino, CA 95014","location":{"lat":37.33122,"lng":-122.03238},"accuracy":0.94,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
         Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
-        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"10600","predirectional":"N","street":"De
-        Anza","suffix":"Blvd","formatted_street":"N De Anza Blvd","city":"Cupertino","county":"Santa
-        Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10600
-        N De Anza Blvd, Cupertino, CA 95014","location":{"lat":37.330648,"lng":-122.031701},"accuracy":0.89,"accuracy_type":"rooftop","source":"Santa
-        Clara County","fields":{"congressional_districts":[{"name":"Congressional
-        District 17","district_number":17,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Khanna","first_name":"Ro","birthday":"1976-09-13","gender":"M","party":"Democrat"},"contact":{"url":"https:\/\/khanna.house.gov","address":"513
-        Cannon HOB; Washington DC 20515-0517","phone":"202-225-2631","contact_form":null},"social":{"rss_url":null,"twitter":"RepRoKhanna","facebook":"RepRoKhanna","youtube":null,"youtube_id":"UCr4KOYv1o1oEQhy1jhhm3pQ"},"references":{"bioguide_id":"K000389","thomas_id":null,"opensecrets_id":"N00026427","lis_id":null,"cspan_id":"31129","govtrack_id":"412684","votesmart_id":"29473","ballotpedia_id":null,"washington_post_id":null,"icpsr_id":"21728","wikipedia_id":"Ro
-        Khanna"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 15","district_number":"15"},"house":{"name":"Assembly District
-        28","district_number":"28"}},"school_districts":{"elementary":{"name":"Cupertino
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"10748","predirectional":"N","street":"DE
+        Anza","suffix":"Blvd","formatted_street":"N DE Anza Blvd","city":"Cupertino","county":"Santa
+        Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"10748
+        N DE Anza Blvd, Cupertino, CA 95014","location":{"lat":37.330219,"lng":-122.03238},"accuracy":0.93,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
         Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
-        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}}]}},{"query":"34.145760590909,-118.15204363636","response":{"results":[{"address_components":{"number":"68","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"68
-        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":1,"accuracy_type":"rooftop","source":"Los
-        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"58","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"58
-        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
-        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"60","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"60
-        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
-        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"10","predirectional":"S","street":"De
-        Lacey","suffix":"Ave","formatted_street":"S De Lacey Ave","city":"Pasadena","county":"Los
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"91","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
+        Loop","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"91
+        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.332709,"lng":-122.03071},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
+        Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"19118","street":"Mariani","suffix":"Ave","formatted_street":"Mariani
+        Ave","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"19118
+        Mariani Ave, Cupertino, CA 95014","location":{"lat":37.330489,"lng":-122.0305},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
+        Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"19479","street":"Mariani","suffix":"Ave","formatted_street":"Mariani
+        Ave","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"19479
+        Mariani Ave, Cupertino, CA 95014","location":{"lat":37.330519,"lng":-122.03008},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
+        Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"19116","street":"Mariani","suffix":"Ave","formatted_street":"Mariani
+        Ave","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"19116
+        Mariani Ave, Cupertino, CA 95014","location":{"lat":37.330407,"lng":-122.030873},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
+        Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"20500","street":"Valley
+        Green","suffix":"Dr","formatted_street":"Valley Green Dr","city":"Cupertino","county":"Santa
+        Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"20500
+        Valley Green Dr, Cupertino, CA 95014","location":{"lat":37.33182,"lng":-122.03239},"accuracy":0.42,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"elementary":{"name":"Cupertino
+        Union Elementary School District","lea_code":"0610290","grade_low":"KG","grade_high":"08"},"secondary":{"name":"Fremont
+        Union High School District","lea_code":"0614430","grade_low":"09","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}}]}},{"query":"34.145760590909,-118.15204363636","response":{"results":[{"address_components":{"number":"10","predirectional":"S","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"S DE Lacey Ave","city":"Pasadena","county":"Los
         Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"10
-        S De Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
+        S DE Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
         Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"69","street":"Mc
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"58","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"58
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
+        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"69","street":"Mc
         Cormick","suffix":"Aly","formatted_street":"Mc Cormick Aly","city":"Pasadena","county":"Los
         Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"69
-        Mc Cormick Aly, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
+        Mc Cormick Aly, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
         Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}}]}},{"query":"37.7815,-122.404933","response":{"results":[{"address_components":{"number":"198","street":"05th","suffix":"St","formatted_street":"05th
-        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"198
-        05th St, San Francisco, CA 94103","location":{"lat":37.781458,"lng":-122.405257},"accuracy":1,"accuracy_type":"rooftop","source":"San
-        Francisco","fields":{"congressional_districts":[{"name":"Congressional District
-        12","district_number":12,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Pelosi","first_name":"Nancy","birthday":"1940-03-26","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/pelosi.house.gov","address":"233
-        Cannon HOB; Washington DC 20515-0512","phone":"202-225-4965","contact_form":null},"social":{"rss_url":"http:\/\/pelosi.house.gov\/atom.xml","twitter":"NancyPelosi","facebook":"NancyPelosi","youtube":"nancypelosi","youtube_id":"UCxPeEcH0xaCK9nBK98EFhDg"},"references":{"bioguide_id":"P000197","thomas_id":"00905","opensecrets_id":"N00007360","lis_id":null,"cspan_id":"6153","govtrack_id":"400314","votesmart_id":"26732","ballotpedia_id":"Nancy
-        Pelosi","washington_post_id":null,"icpsr_id":"15448","wikipedia_id":"Nancy
-        Pelosi"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 11","district_number":"11"},"house":{"name":"Assembly District
-        17","district_number":"17"}},"school_districts":{"unified":{"name":"San Francisco
-        Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"194","street":"05th","suffix":"St","formatted_street":"05th
-        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"194
-        05th St, San Francisco, CA 94103","location":{"lat":37.781458,"lng":-122.405257},"accuracy":0.9,"accuracy_type":"rooftop","source":"San
-        Francisco","fields":{"congressional_districts":[{"name":"Congressional District
-        12","district_number":12,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Pelosi","first_name":"Nancy","birthday":"1940-03-26","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/pelosi.house.gov","address":"233
-        Cannon HOB; Washington DC 20515-0512","phone":"202-225-4965","contact_form":null},"social":{"rss_url":"http:\/\/pelosi.house.gov\/atom.xml","twitter":"NancyPelosi","facebook":"NancyPelosi","youtube":"nancypelosi","youtube_id":"UCxPeEcH0xaCK9nBK98EFhDg"},"references":{"bioguide_id":"P000197","thomas_id":"00905","opensecrets_id":"N00007360","lis_id":null,"cspan_id":"6153","govtrack_id":"400314","votesmart_id":"26732","ballotpedia_id":"Nancy
-        Pelosi","washington_post_id":null,"icpsr_id":"15448","wikipedia_id":"Nancy
-        Pelosi"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 11","district_number":"11"},"house":{"name":"Assembly District
-        17","district_number":"17"}},"school_districts":{"unified":{"name":"San Francisco
-        Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"906","street":"Howard","suffix":"St","formatted_street":"Howard
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"60","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"60
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
+        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"68","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"68
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
+        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"1","predirectional":"N","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"N DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91103","country":"US"},"formatted_address":"1
+        N DE Lacey Ave, Pasadena, CA 91103","location":{"lat":34.145759,"lng":-118.15223},"accuracy":0.98,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"1","predirectional":"S","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"S DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"1
+        S DE Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145759,"lng":-118.15223},"accuracy":0.98,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"22","predirectional":"S","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"S DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"22
+        S DE Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145407,"lng":-118.152227},"accuracy":0.97,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"25","predirectional":"N","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"N DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91103","country":"US"},"formatted_address":"25
+        N DE Lacey Ave, Pasadena, CA 91103","location":{"lat":34.146409,"lng":-118.152234},"accuracy":0.96,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"85","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"85
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145759,"lng":-118.15223},"accuracy":0.47,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"1","street":"Fraser","suffix":"Aly","formatted_street":"Fraser
+        Aly","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"1
+        Fraser Aly, Pasadena, CA 91105","location":{"lat":34.145407,"lng":-118.152227},"accuracy":0.46,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"43","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"43
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145766,"lng":-118.15141},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"100","street":"Christiansen","suffix":"Aly","formatted_street":"Christiansen
+        Aly","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91103","country":"US"},"formatted_address":"100
+        Christiansen Aly, Pasadena, CA 91103","location":{"lat":34.146409,"lng":-118.152234},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}}]}},{"query":"37.7815,-122.404933","response":{"results":[{"address_components":{"number":"906","street":"Howard","suffix":"St","formatted_street":"Howard
         St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"906
-        Howard St, San Francisco, CA 94103","location":{"lat":37.781458,"lng":-122.405257},"accuracy":0.9,"accuracy_type":"rooftop","source":"San
+        Howard St, San Francisco, CA 94103","location":{"lat":37.781471,"lng":-122.405246},"accuracy":1,"accuracy_type":"rooftop","source":"San
         Francisco","fields":{"congressional_districts":[{"name":"Congressional District
-        12","district_number":12,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Pelosi","first_name":"Nancy","birthday":"1940-03-26","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/pelosi.house.gov","address":"233
-        Cannon HOB; Washington DC 20515-0512","phone":"202-225-4965","contact_form":null},"social":{"rss_url":"http:\/\/pelosi.house.gov\/atom.xml","twitter":"NancyPelosi","facebook":"NancyPelosi","youtube":"nancypelosi","youtube_id":"UCxPeEcH0xaCK9nBK98EFhDg"},"references":{"bioguide_id":"P000197","thomas_id":"00905","opensecrets_id":"N00007360","lis_id":null,"cspan_id":"6153","govtrack_id":"400314","votesmart_id":"26732","ballotpedia_id":"Nancy
-        Pelosi","washington_post_id":null,"icpsr_id":"15448","wikipedia_id":"Nancy
-        Pelosi"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 11","district_number":"11"},"house":{"name":"Assembly District
-        17","district_number":"17"}},"school_districts":{"unified":{"name":"San Francisco
-        Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"206","street":"05th","suffix":"St","formatted_street":"05th
+        11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"194","street":"5th","suffix":"St","formatted_street":"5th
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"194
+        5th St, San Francisco, CA 94103","location":{"lat":37.781466,"lng":-122.405248},"accuracy":1,"accuracy_type":"rooftop","source":"San
+        Francisco","fields":{"congressional_districts":[{"name":"Congressional District
+        11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"198","street":"5th","suffix":"St","formatted_street":"5th
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"198
+        5th St, San Francisco, CA 94103","location":{"lat":37.781467,"lng":-122.405249},"accuracy":1,"accuracy_type":"rooftop","source":"San
+        Francisco","fields":{"congressional_districts":[{"name":"Congressional District
+        11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"206","street":"5th","suffix":"St","formatted_street":"5th
         St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"206
-        05th St, San Francisco, CA 94103","location":{"lat":37.781187,"lng":-122.404925},"accuracy":0.9,"accuracy_type":"rooftop","source":"San
+        5th St, San Francisco, CA 94103","location":{"lat":37.781187,"lng":-122.404925},"accuracy":0.99,"accuracy_type":"rooftop","source":"San
         Francisco","fields":{"congressional_districts":[{"name":"Congressional District
-        12","district_number":12,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Pelosi","first_name":"Nancy","birthday":"1940-03-26","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/pelosi.house.gov","address":"233
-        Cannon HOB; Washington DC 20515-0512","phone":"202-225-4965","contact_form":null},"social":{"rss_url":"http:\/\/pelosi.house.gov\/atom.xml","twitter":"NancyPelosi","facebook":"NancyPelosi","youtube":"nancypelosi","youtube_id":"UCxPeEcH0xaCK9nBK98EFhDg"},"references":{"bioguide_id":"P000197","thomas_id":"00905","opensecrets_id":"N00007360","lis_id":null,"cspan_id":"6153","govtrack_id":"400314","votesmart_id":"26732","ballotpedia_id":"Nancy
-        Pelosi","washington_post_id":null,"icpsr_id":"15448","wikipedia_id":"Nancy
-        Pelosi"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 11","district_number":"11"},"house":{"name":"Assembly District
-        17","district_number":"17"}},"school_districts":{"unified":{"name":"San Francisco
-        Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"190","street":"05th","suffix":"St","formatted_street":"05th
-        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"190
-        05th St, San Francisco, CA 94103","location":{"lat":37.781508,"lng":-122.405329},"accuracy":0.9,"accuracy_type":"rooftop","source":"San
+        11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"901","street":"Howard","suffix":"St","formatted_street":"Howard
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"901
+        Howard St, San Francisco, CA 94103","location":{"lat":37.781185,"lng":-122.404921},"accuracy":0.99,"accuracy_type":"rooftop","source":"San
         Francisco","fields":{"congressional_districts":[{"name":"Congressional District
-        12","district_number":12,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Pelosi","first_name":"Nancy","birthday":"1940-03-26","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/pelosi.house.gov","address":"233
-        Cannon HOB; Washington DC 20515-0512","phone":"202-225-4965","contact_form":null},"social":{"rss_url":"http:\/\/pelosi.house.gov\/atom.xml","twitter":"NancyPelosi","facebook":"NancyPelosi","youtube":"nancypelosi","youtube_id":"UCxPeEcH0xaCK9nBK98EFhDg"},"references":{"bioguide_id":"P000197","thomas_id":"00905","opensecrets_id":"N00007360","lis_id":null,"cspan_id":"6153","govtrack_id":"400314","votesmart_id":"26732","ballotpedia_id":"Nancy
-        Pelosi","washington_post_id":null,"icpsr_id":"15448","wikipedia_id":"Nancy
-        Pelosi"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 11","district_number":"11"},"house":{"name":"Assembly District
-        17","district_number":"17"}},"school_districts":{"unified":{"name":"San Francisco
-        Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}}]}}]}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 17:35:15 GMT
-recorded_with: VCR 4.0.0
+        11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"900","street":"Howard","suffix":"St","formatted_street":"Howard
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"900
+        Howard St, San Francisco, CA 94103","location":{"lat":37.7815,"lng":-122.404933},"accuracy":0.5,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"227","street":"5th","suffix":"St","formatted_street":"5th
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"227
+        5th St, San Francisco, CA 94103","location":{"lat":37.781076,"lng":-122.404404},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"400","street":"Tehama","suffix":"St","formatted_street":"Tehama
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"400
+        Tehama St, San Francisco, CA 94103","location":{"lat":37.781076,"lng":-122.404404},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"177","street":"5th","suffix":"St","formatted_street":"5th
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"177
+        5th St, San Francisco, CA 94103","location":{"lat":37.781925,"lng":-122.405466},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"400","street":"Natoma","suffix":"St","formatted_street":"Natoma
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"400
+        Natoma St, San Francisco, CA 94103","location":{"lat":37.781925,"lng":-122.405466},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"928","street":"Howard","suffix":"St","formatted_street":"Howard
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"928
+        Howard St, San Francisco, CA 94103","location":{"lat":37.780878,"lng":-122.405719},"accuracy":0.44,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"80","street":"Mary","suffix":"St","formatted_street":"Mary
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"80
+        Mary St, San Francisco, CA 94103","location":{"lat":37.781306,"lng":-122.406248},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"432","street":"Natoma","suffix":"St","formatted_street":"Natoma
+        St","city":"San Francisco","county":"San Francisco County","state":"CA","zip":"94103","country":"US"},"formatted_address":"432
+        Natoma St, San Francisco, CA 94103","location":{"lat":37.781306,"lng":-122.406248},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 11","district_number":11,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:11","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 17","district_number":"17","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:17","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 11","district_number":"11","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:11","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"San
+        Francisco Unified School District","lea_code":"0634410","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}}]}}]}'
+  recorded_at: Tue, 05 Jul 2022 22:21:45 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/canadian.yml
+++ b/spec/vcr_cassettes/canadian.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.geocod.io/v1.7/geocode?api_key=secret_api_key&fields=timezone,cd118,provriding,riding,stateleg-next
+    body:
+      encoding: UTF-8
+      string: '["1 Infinite Loop Cupertino CA 95014","356 Yonge St, Toronto, ON M5G,
+        Canada","3475 Bd Sainte-Anne, Beauport, QC G1E 3L5, Canada"]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Cache-Control:
+      - no-cache, private
+      Date:
+      - Tue, 05 Jul 2022 23:16:29 GMT
+      X-Billable-Lookups-Count:
+      - '3'
+      X-Billable-Fields-Count:
+      - '9'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST
+      Access-Control-Allow-Headers:
+      - Content-Type, User-Agent
+      Access-Control-Expose-Headers:
+      - Request-Handler
+      Request-Handler:
+      - api228
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:C52C_05A15419:0050_62C4C64C_372DA:3D9A
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"results":[{"query":"1 Infinite Loop Cupertino CA 95014","response":{"input":{"address_components":{"number":"1","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
+        Loop","city":"Cupertino","state":"CA","zip":"95014","country":"US"},"formatted_address":"1
+        Infinite Loop, Cupertino, CA 95014"},"results":[{"address_components":{"number":"1","street":"Infinite","suffix":"Loop","formatted_street":"Infinite
+        Loop","city":"Cupertino","county":"Santa Clara County","state":"CA","zip":"95014","country":"US"},"formatted_address":"1
+        Infinite Loop, Cupertino, CA 95014","location":{"lat":37.331524,"lng":-122.030231},"accuracy":1,"accuracy_type":"rooftop","source":"City
+        of Cupertino","fields":{"congressional_districts":[{"name":"Congressional
+        District 17","district_number":17,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:17","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 26","district_number":"26","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:26","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 13","district_number":"13","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:13","is_upcoming_state_legislative_district":true,"proportion":1}]},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}}]}},{"query":"356 Yonge St, Toronto, ON M5G,
+        Canada","response":{"input":{"address_components":{"number":"356","street":"Yonge","suffix":"St","formatted_street":"Yonge
+        St","city":"Toronto","state":"ON","zip":"M5G","country":"CA"},"formatted_address":"356
+        Yonge St, Toronto, ON M5G"},"results":[{"address_components":{"number":"356","street":"Yonge","suffix":"St","formatted_street":"Yonge
+        St","city":"Toronto","state":"ON","zip":"M5G","country":"CA"},"formatted_address":"356
+        Yonge St, Toronto, ON M5G","location":{"lat":43.658192,"lng":-79.382046},"accuracy":1,"accuracy_type":"rooftop","source":"City
+        of Toronto","fields":{"timezone":{"name":"America\/Toronto","utc_offset":-5,"observes_dst":true,"abbreviation":"EST","source":"\u00a9
+        OpenStreetMap contributors"},"riding":{"code":"35110","ocd_id":"ocd-division\/country:ca\/ed:35110-2013","name_french":"University--Rosedale","name_english":"University--Rosedale","source":"Statistics
+        Canada"},"provincial_riding":{"ocd_id":"ocd-division\/country:ca\/province:on\/ed:112-2015","name_french":"University
+        - Rosedale","name_english":"University - Rosedale","source":"Elections Ontario"}}}]}},{"query":"3475
+        Bd Sainte-Anne, Beauport, QC G1E 3L5, Canada","response":{"input":{"address_components":{"number":"3475","city":"Beauport","state":"QC","zip":"G1E","country":"CA"},"formatted_address":"3475,
+        Beauport, QC G1E"},"results":[{"address_components":{"city":"Beauport","state":"QC","zip":"G1E","country":"CA"},"formatted_address":"Beauport,
+        QC G1E","location":{"lat":46.8588,"lng":-71.192},"accuracy":0.35,"accuracy_type":"place","source":"CanVec+
+        by Natural Resources Canada","fields":{"timezone":{"name":"America\/Toronto","utc_offset":-5,"observes_dst":true,"abbreviation":"EST","source":"\u00a9
+        OpenStreetMap contributors"},"riding":{"code":"24008","ocd_id":"ocd-division\/country:ca\/ed:24008-2013","name_french":"Beauport--Limoilou","name_english":"Beauport--Limoilou","source":"Statistics
+        Canada"},"provincial_riding":{"ocd_id":"ocd-division\/country:ca\/province:qc\/ed:742-2017","name_french":"Montmorency","name_english":"Montmorency","source":"Contains
+        open data granted under the Chief Electoral Officer''s Open Data User Licence
+        available at http:\/\/dgeq.org\/en\/. The fact of granting the licence in
+        no way implies that the Chief Electoral Officer approves the use made of the
+        open data."}}},{"address_components":{"city":"Beauport","state":"QC","zip":"G1B","country":"CA"},"formatted_address":"Beauport,
+        QC G1B","location":{"lat":46.9263,"lng":-71.2258},"accuracy":0.25,"accuracy_type":"place","source":"CanVec+
+        by Natural Resources Canada","fields":{"timezone":{"name":"America\/Toronto","utc_offset":-5,"observes_dst":true,"abbreviation":"EST","source":"\u00a9
+        OpenStreetMap contributors"},"riding":{"code":"24020","ocd_id":"ocd-division\/country:ca\/ed:24020-2013","name_french":"Beauport--C\u00f4te-de-Beaupr\u00e9--\u00cele
+        d\u2019Orl\u00e9ans--Charlevoix","name_english":"Beauport--C\u00f4te-de-Beaupr\u00e9--\u00cele
+        d\u2019Orl\u00e9ans--Charlevoix","source":"Statistics Canada"},"provincial_riding":{"ocd_id":"ocd-division\/country:ca\/province:qc\/ed:742-2017","name_french":"Montmorency","name_english":"Montmorency","source":"Contains
+        open data granted under the Chief Electoral Officer''s Open Data User Licence
+        available at http:\/\/dgeq.org\/en\/. The fact of granting the licence in
+        no way implies that the Chief Electoral Officer approves the use made of the
+        open data."}}},{"address_components":{"city":"Beauport","state":"QC","zip":"G1C","country":"CA"},"formatted_address":"Beauport,
+        QC G1C","location":{"lat":46.8801,"lng":-71.196},"accuracy":0.25,"accuracy_type":"place","source":"CanVec+
+        by Natural Resources Canada","fields":{"timezone":{"name":"America\/Toronto","utc_offset":-5,"observes_dst":true,"abbreviation":"EST","source":"\u00a9
+        OpenStreetMap contributors"},"riding":{"code":"24008","ocd_id":"ocd-division\/country:ca\/ed:24008-2013","name_french":"Beauport--Limoilou","name_english":"Beauport--Limoilou","source":"Statistics
+        Canada"},"provincial_riding":{"ocd_id":"ocd-division\/country:ca\/province:qc\/ed:742-2017","name_french":"Montmorency","name_english":"Montmorency","source":"Contains
+        open data granted under the Chief Electoral Officer''s Open Data User Licence
+        available at http:\/\/dgeq.org\/en\/. The fact of granting the licence in
+        no way implies that the Chief Electoral Officer approves the use made of the
+        open data."}}}]}}]}'
+  recorded_at: Tue, 05 Jul 2022 23:16:29 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/geocode.yml
+++ b/spec/vcr_cassettes/geocode.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.geocod.io/v1.2/geocode?api_key=secret_api_key&q=54%20West%20Colorado%20Boulevard%20Pasadena%20CA%2091105
+    uri: http://api.geocod.io/v1.7/geocode?api_key=secret_api_key&q=54%20West%20Colorado%20Boulevard%20Pasadena%20CA%2091105
     body:
       encoding: US-ASCII
       string: ''
@@ -18,39 +18,44 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 17:35:08 GMT
-      Request-Handler:
-      - api35
+      - Tue, 05 Jul 2022 22:21:36 GMT
+      X-Billable-Lookups-Count:
+      - '1'
+      X-Billable-Fields-Count:
+      - '0'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
       Access-Control-Expose-Headers:
       - Request-Handler
+      Request-Handler:
+      - api228
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FDE3_05A15419:0050_62C4B970_53B75:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
       string: '{"input":{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
         Colorado Blvd","city":"Pasadena","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
-        W Colorado Blvd, Pasadena, CA 91105"},"results":[{"address_components":{"number":"54","predirectional":"E","street":"Colorado","suffix":"Blvd","formatted_street":"E
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
-        E Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145499,"lng":-118.14932},"accuracy":1,"accuracy_type":"rooftop","source":"Los
-        Angeles"},{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        W Colorado Blvd, Pasadena, CA 91105"},"results":[{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
         Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
         W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145375,"lng":-118.151622},"accuracy":1,"accuracy_type":"rooftop","source":"Los
+        Angeles"},{"address_components":{"number":"54","predirectional":"E","street":"Colorado","suffix":"Blvd","formatted_street":"E
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
+        E Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145499,"lng":-118.14932},"accuracy":0.8,"accuracy_type":"rooftop","source":"Los
         Angeles"}]}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 17:35:08 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Tue, 05 Jul 2022 22:21:36 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/geocode_bad_address.yml
+++ b/spec/vcr_cassettes/geocode_bad_address.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.geocod.io/v1.2/geocode?api_key=secret_api_key&q=%20,%20,%20
+    uri: http://api.geocod.io/v1.7/geocode?api_key=secret_api_key&q=%20,%20,%20
     body:
       encoding: US-ASCII
       string: ''
@@ -16,29 +16,38 @@ http_interactions:
   response:
     status:
       code: 422
-      message: Unprocessable Entity
+      message: Unprocessable Content
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 17:35:11 GMT
+      - Tue, 05 Jul 2022 22:21:43 GMT
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
+      X-Billable-Lookups-Count:
+      - '0'
+      X-Billable-Fields-Count:
+      - '0'
+      Access-Control-Expose-Headers:
+      - Request-Handler
+      Request-Handler:
+      - api228
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FDFC_05A15419:0050_62C4B977_54288:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
       string: '{"error":"Could not geocode address. Postal code or city required."}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 17:35:11 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Tue, 05 Jul 2022 22:21:43 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/geocode_with_fields.yml
+++ b/spec/vcr_cassettes/geocode_with_fields.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.geocod.io/v1.2/geocode?api_key=secret_api_key&fields=cd,stateleg,school,timezone&q=54%20West%20Colorado%20Boulevard%20Pasadena%20CA%2091105
+    uri: http://api.geocod.io/v1.7/geocode?api_key=secret_api_key&fields=cd118,stateleg-next,school,timezone&q=54%20West%20Colorado%20Boulevard%20Pasadena%20CA%2091105
     body:
       encoding: US-ASCII
       string: ''
@@ -18,69 +18,54 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 17:35:07 GMT
-      Request-Handler:
-      - api19
+      - Tue, 05 Jul 2022 22:21:35 GMT
+      X-Billable-Lookups-Count:
+      - '1'
+      X-Billable-Fields-Count:
+      - '4'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
       Access-Control-Expose-Headers:
       - Request-Handler
+      Request-Handler:
+      - api228
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FDE1_05A15419:0050_62C4B96F_53AB7:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
       string: '{"input":{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
         Colorado Blvd","city":"Pasadena","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
-        W Colorado Blvd, Pasadena, CA 91105"},"results":[{"address_components":{"number":"54","predirectional":"E","street":"Colorado","suffix":"Blvd","formatted_street":"E
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
-        E Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145499,"lng":-118.14932},"accuracy":1,"accuracy_type":"rooftop","source":"Los
-        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        W Colorado Blvd, Pasadena, CA 91105"},"results":[{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
         Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
         W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145375,"lng":-118.151622},"accuracy":1,"accuracy_type":"rooftop","source":"Los
         Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}}]}'
-    http_version:
-  recorded_at: Fri, 16 Feb 2018 17:35:07 GMT
-recorded_with: VCR 4.0.0
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"54","predirectional":"E","street":"Colorado","suffix":"Blvd","formatted_street":"E
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
+        E Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145499,"lng":-118.14932},"accuracy":0.8,"accuracy_type":"rooftop","source":"Los
+        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}}]}'
+  recorded_at: Tue, 05 Jul 2022 22:21:35 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/geocode_with_fields_legacy.yml
+++ b/spec/vcr_cassettes/geocode_with_fields_legacy.yml
@@ -1,0 +1,91 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.geocod.io/v1.7/geocode?api_key=secret_api_key&fields=cd,stateleg-next,school,timezone&q=54%20West%20Colorado%20Boulevard%20Pasadena%20CA%2091105
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Cache-Control:
+      - no-cache, private
+      Date:
+      - Tue, 05 Jul 2022 22:28:53 GMT
+      X-Billable-Lookups-Count:
+      - '1'
+      X-Billable-Fields-Count:
+      - '4'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST
+      Access-Control-Allow-Headers:
+      - Content-Type, User-Agent
+      Access-Control-Expose-Headers:
+      - Request-Handler
+      Request-Handler:
+      - api245
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FF00_05A15419:0050_62C4BB25_6FB9C:3D82
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"input":{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
+        W Colorado Blvd, Pasadena, CA 91105"},"results":[{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145375,"lng":-118.151622},"accuracy":1,"accuracy_type":"rooftop","source":"Los
+        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
+        27","district_number":27,"ocd_id":null,"congress_number":"117th","congress_years":"2021-2023","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
+        Rayburn House Office Building Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
+        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
+        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
+        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
+        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
+        Feinstein"},"source":"Legislator data is originally collected and aggregated
+        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Padilla","first_name":"Alejandro","birthday":"1973-03-22","gender":"M","party":"Democrat"},"contact":{"url":"https:\/\/www.padilla.senate.gov","address":"112
+        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.padilla.senate.gov\/contact\/"},"social":{"rss_url":null,"twitter":"SenAlexPadilla","facebook":null,"youtube":null,"youtube_id":null},"references":{"bioguide_id":"P000145","thomas_id":null,"opensecrets_id":"N00047888","lis_id":"S413","cspan_id":null,"govtrack_id":"456856","votesmart_id":null,"ballotpedia_id":"Alex
+        Padilla","washington_post_id":null,"icpsr_id":null,"wikipedia_id":"Alex Padilla"},"source":"Legislator
+        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"54","predirectional":"E","street":"Colorado","suffix":"Blvd","formatted_street":"E
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
+        E Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145499,"lng":-118.14932},"accuracy":0.8,"accuracy_type":"rooftop","source":"Los
+        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
+        27","district_number":27,"ocd_id":null,"congress_number":"117th","congress_years":"2021-2023","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
+        Rayburn House Office Building Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
+        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
+        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
+        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
+        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
+        Feinstein"},"source":"Legislator data is originally collected and aggregated
+        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Padilla","first_name":"Alejandro","birthday":"1973-03-22","gender":"M","party":"Democrat"},"contact":{"url":"https:\/\/www.padilla.senate.gov","address":"112
+        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.padilla.senate.gov\/contact\/"},"social":{"rss_url":null,"twitter":"SenAlexPadilla","facebook":null,"youtube":null,"youtube_id":null},"references":{"bioguide_id":"P000145","thomas_id":null,"opensecrets_id":"N00047888","lis_id":"S413","cspan_id":null,"govtrack_id":"456856","votesmart_id":null,"ballotpedia_id":"Alex
+        Padilla","washington_post_id":null,"icpsr_id":null,"wikipedia_id":"Alex Padilla"},"source":"Legislator
+        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}}]}'
+  recorded_at: Tue, 05 Jul 2022 22:28:53 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/geocode_with_postdirectional.yml
+++ b/spec/vcr_cassettes/geocode_with_postdirectional.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.geocod.io/v1.2/geocode?api_key=secret_api_key&q=1600%20Pennsylvania%20Ave%20NW%20Washington%20DC%2020500
+    uri: http://api.geocod.io/v1.7/geocode?api_key=secret_api_key&q=1600%20Pennsylvania%20Ave%20NW%20Washington%20DC%2020500
     body:
       encoding: US-ASCII
       string: ''
@@ -18,36 +18,44 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 17:35:08 GMT
-      Request-Handler:
-      - api35
+      - Tue, 05 Jul 2022 22:21:36 GMT
+      X-Billable-Lookups-Count:
+      - '1'
+      X-Billable-Fields-Count:
+      - '0'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
       Access-Control-Expose-Headers:
       - Request-Handler
+      Request-Handler:
+      - api245
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FDE2_05A15419:0050_62C4B970_53B2E:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
       string: '{"input":{"address_components":{"number":"1600","street":"Pennsylvania","suffix":"Ave","postdirectional":"NW","formatted_street":"Pennsylvania
         Ave NW","city":"Washington","state":"DC","zip":"20500","country":"US"},"formatted_address":"1600
         Pennsylvania Ave NW, Washington, DC 20500"},"results":[{"address_components":{"number":"1600","street":"Pennsylvania","suffix":"Ave","postdirectional":"NW","formatted_street":"Pennsylvania
         Ave NW","city":"Washington","county":"District of Columbia","state":"DC","zip":"20500","country":"US"},"formatted_address":"1600
-        Pennsylvania Ave NW, Washington, DC 20500","location":{"lat":38.897675,"lng":-77.036547},"accuracy":1,"accuracy_type":"rooftop","source":"City
-        of Washington"}]}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 17:35:08 GMT
-recorded_with: VCR 4.0.0
+        Pennsylvania Ave NW, Washington, DC 20500","location":{"lat":38.897675,"lng":-77.036547},"accuracy":1,"accuracy_type":"rooftop","source":"Statewide
+        DC"},{"address_components":{"number":"1600","street":"Pennsylvania","suffix":"Ave","postdirectional":"SE","formatted_street":"Pennsylvania
+        Ave SE","city":"Washington","county":"District of Columbia","state":"DC","zip":"20003","country":"US"},"formatted_address":"1600
+        Pennsylvania Ave SE, Washington, DC 20003","location":{"lat":38.879213,"lng":-76.981976},"accuracy":0.7,"accuracy_type":"rooftop","source":"Statewide
+        DC"}]}'
+  recorded_at: Tue, 05 Jul 2022 22:21:36 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/invalid_key.yml
+++ b/spec/vcr_cassettes/invalid_key.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.geocod.io/v1.2/geocode?api_key=secret_api_key&q=54%20West%20Colorado%20Boulevard%20Pasadena%20CA%2091105
+    uri: http://api.geocod.io/v1.7/geocode?api_key=secret_api_key&q=54%20West%20Colorado%20Boulevard%20Pasadena%20CA%2091105
     body:
       encoding: US-ASCII
       string: ''
@@ -18,27 +18,42 @@ http_interactions:
       code: 403
       message: Forbidden
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 19:20:32 GMT
+      - Tue, 05 Jul 2022 22:29:57 GMT
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
+      X-Billable-Lookups-Count:
+      - '0'
+      X-Billable-Fields-Count:
+      - '0'
+      Access-Control-Expose-Headers:
+      - Request-Handler
+      Request-Handler:
+      - api286
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FF28_05A15419:0050_62C4BB65_73B1B:3D82
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Period:
+      - '60'
+      Connection:
+      - close
     body:
       encoding: UTF-8
       string: '{"error":"Invalid API key"}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 19:20:32 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Tue, 05 Jul 2022 22:29:57 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/parse.yml
+++ b/spec/vcr_cassettes/parse.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.geocod.io/v1.2/parse?api_key=secret_api_key&q=54%20West%20Colorado%20Boulevard%20Pasadena%20CA%2091105
+    uri: http://api.geocod.io/v1.7/parse?api_key=secret_api_key&q=54%20West%20Colorado%20Boulevard%20Pasadena%20CA%2091105
     body:
       encoding: US-ASCII
       string: ''
@@ -18,33 +18,34 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 19:38:21 GMT
-      Request-Handler:
-      - api7
+      - Tue, 05 Jul 2022 22:21:35 GMT
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
       Access-Control-Expose-Headers:
       - Request-Handler
+      Request-Handler:
+      - api245
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FDE0_05A15419:0050_62C4B96F_53A6D:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
       string: '{"address_components":{"number":"54","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
         Colorado Blvd","city":"Pasadena","state":"CA","zip":"91105","country":"US"},"formatted_address":"54
         W Colorado Blvd, Pasadena, CA 91105"}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 19:38:21 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Tue, 05 Jul 2022 22:21:35 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/reverse.yml
+++ b/spec/vcr_cassettes/reverse.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.geocod.io/v1.2/reverse?api_key=secret_api_key&q=34.145760590909,-118.15204363636
+    uri: http://api.geocod.io/v1.7/reverse?api_key=secret_api_key&q=34.145760590909,-118.15204363636
     body:
       encoding: US-ASCII
       string: ''
@@ -18,47 +18,80 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 17:35:12 GMT
-      Request-Handler:
-      - api19
+      - Tue, 05 Jul 2022 22:21:47 GMT
+      X-Billable-Lookups-Count:
+      - '1'
+      X-Billable-Fields-Count:
+      - '0'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
       Access-Control-Expose-Headers:
       - Request-Handler
+      Request-Handler:
+      - api245
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FE02_05A15419:0050_62C4B97B_54674:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
-      string: '{"results":[{"address_components":{"number":"68","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"68
-        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":1,"accuracy_type":"rooftop","source":"Los
+      string: '{"results":[{"address_components":{"number":"10","predirectional":"S","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"S DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"10
+        S DE Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
         Angeles"},{"address_components":{"number":"58","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
         Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"58
-        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
-        Angeles"},{"address_components":{"number":"60","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"60
-        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
-        Angeles"},{"address_components":{"number":"10","predirectional":"S","street":"De
-        Lacey","suffix":"Ave","formatted_street":"S De Lacey Ave","city":"Pasadena","county":"Los
-        Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"10
-        S De Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
         Angeles"},{"address_components":{"number":"69","street":"Mc Cormick","suffix":"Aly","formatted_street":"Mc
         Cormick Aly","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"69
-        Mc Cormick Aly, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
-        Angeles"}]}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 17:35:12 GMT
-recorded_with: VCR 4.0.0
+        Mc Cormick Aly, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
+        Angeles"},{"address_components":{"number":"60","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"60
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
+        Angeles"},{"address_components":{"number":"68","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"68
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
+        Angeles"},{"address_components":{"number":"1","predirectional":"N","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"N DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91103","country":"US"},"formatted_address":"1
+        N DE Lacey Ave, Pasadena, CA 91103","location":{"lat":34.145759,"lng":-118.15223},"accuracy":0.98,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"1","predirectional":"S","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"S DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"1
+        S DE Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145759,"lng":-118.15223},"accuracy":0.98,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"22","predirectional":"S","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"S DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"22
+        S DE Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145407,"lng":-118.152227},"accuracy":0.97,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"25","predirectional":"N","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"N DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91103","country":"US"},"formatted_address":"25
+        N DE Lacey Ave, Pasadena, CA 91103","location":{"lat":34.146409,"lng":-118.152234},"accuracy":0.96,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"85","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"85
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145759,"lng":-118.15223},"accuracy":0.47,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"1","street":"Fraser","suffix":"Aly","formatted_street":"Fraser
+        Aly","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"1
+        Fraser Aly, Pasadena, CA 91105","location":{"lat":34.145407,"lng":-118.152227},"accuracy":0.46,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"43","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"43
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145766,"lng":-118.15141},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"},{"address_components":{"number":"100","street":"Christiansen","suffix":"Aly","formatted_street":"Christiansen
+        Aly","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91103","country":"US"},"formatted_address":"100
+        Christiansen Aly, Pasadena, CA 91103","location":{"lat":34.146409,"lng":-118.152234},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau"}]}'
+  recorded_at: Tue, 05 Jul 2022 22:21:47 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/reverse_with_fields.yml
+++ b/spec/vcr_cassettes/reverse_with_fields.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.geocod.io/v1.2/reverse?api_key=secret_api_key&fields=cd,stateleg,school,timezone&q=34.145760590909,-118.15204363636
+    uri: http://api.geocod.io/v1.7/reverse?api_key=secret_api_key&fields=cd118,stateleg-next,school,timezone&q=34.145760590909,-118.15204363636
     body:
       encoding: US-ASCII
       string: ''
@@ -18,123 +18,146 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.12.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
-      X-Powered-By:
-      - PHP/7.1.14
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 16 Feb 2018 17:35:13 GMT
-      Request-Handler:
-      - api7
+      - Tue, 05 Jul 2022 22:21:46 GMT
+      X-Billable-Lookups-Count:
+      - '1'
+      X-Billable-Fields-Count:
+      - '4'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
       Access-Control-Expose-Headers:
       - Request-Handler
+      Request-Handler:
+      - api228
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FE01_05A15419:0050_62C4B97A_545C7:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
-      string: '{"results":[{"address_components":{"number":"68","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"68
-        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":1,"accuracy_type":"rooftop","source":"Los
-        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"58","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"58
-        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
-        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"60","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
-        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"60
-        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
-        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"10","predirectional":"S","street":"De
-        Lacey","suffix":"Ave","formatted_street":"S De Lacey Ave","city":"Pasadena","county":"Los
+      string: '{"results":[{"address_components":{"number":"10","predirectional":"S","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"S DE Lacey Ave","city":"Pasadena","county":"Los
         Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"10
-        S De Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
+        S DE Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
         Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}},{"address_components":{"number":"69","street":"Mc
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"58","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"58
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
+        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"69","street":"Mc
         Cormick","suffix":"Aly","formatted_street":"Mc Cormick Aly","city":"Pasadena","county":"Los
         Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"69
-        Mc Cormick Aly, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.9,"accuracy_type":"rooftop","source":"Los
+        Mc Cormick Aly, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
         Angeles","fields":{"congressional_districts":[{"name":"Congressional District
-        27","district_number":27,"congress_number":"115th","congress_years":"2017-2019","proportion":1,"current_legislators":[{"type":"representative","bio":{"last_name":"Chu","first_name":"Judy","birthday":"1953-07-07","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/chu.house.gov","address":"2423
-        Rayburn HOB; Washington DC 20515-0527","phone":"202-225-5464","contact_form":null},"social":{"rss_url":"http:\/\/chu.house.gov\/rss.xml","twitter":"RepJudyChu","facebook":"RepJudyChu","youtube":"RepJudyChu","youtube_id":"UCfcbYOvdEXZNelM8T05nK-w"},"references":{"bioguide_id":"C001080","thomas_id":"01970","opensecrets_id":"N00030600","lis_id":null,"cspan_id":"92573","govtrack_id":"412379","votesmart_id":"16539","ballotpedia_id":"Judy
-        Chu","washington_post_id":null,"icpsr_id":"20955","wikipedia_id":"Judy Chu"},"source":"Legislator
-        data is originally collected and aggregated by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Feinstein","first_name":"Dianne","birthday":"1933-06-22","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.feinstein.senate.gov","address":"331
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3841","contact_form":"https:\/\/www.feinstein.senate.gov\/public\/index.cfm\/e-mail-me"},"social":{"rss_url":"http:\/\/www.feinstein.senate.gov\/public\/?a=rss.feed","twitter":"SenFeinstein","facebook":"senatorfeinstein","youtube":"SenatorFeinstein","youtube_id":"UCtVC--6LR0ff2aOP8THpuEw"},"references":{"bioguide_id":"F000062","thomas_id":"01332","opensecrets_id":"N00007364","lis_id":"S221","cspan_id":"13061","govtrack_id":"300043","votesmart_id":"53273","ballotpedia_id":"Dianne
-        Feinstein","washington_post_id":null,"icpsr_id":"49300","wikipedia_id":"Dianne
-        Feinstein"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"},{"type":"senator","bio":{"last_name":"Harris","first_name":"Kamala","birthday":"1964-10-20","gender":"F","party":"Democrat"},"contact":{"url":"https:\/\/www.harris.senate.gov","address":"112
-        Hart Senate Office Building Washington DC 20510","phone":"202-224-3553","contact_form":"https:\/\/www.harris.senate.gov\/contact"},"social":{"rss_url":null,"twitter":"SenKamalaHarris","facebook":"SenatorKamalaHarris","youtube":null,"youtube_id":null},"references":{"bioguide_id":"H001075","thomas_id":null,"opensecrets_id":"N00036915","lis_id":"S387","cspan_id":"1018696","govtrack_id":"412678","votesmart_id":"120012","ballotpedia_id":"Kamala
-        Harris","washington_post_id":null,"icpsr_id":"41701","wikipedia_id":"Kamala
-        Harris"},"source":"Legislator data is originally collected and aggregated
-        by https:\/\/github.com\/unitedstates\/"}]}],"state_legislative_districts":{"senate":{"name":"State
-        Senate District 25","district_number":"25"},"house":{"name":"Assembly District
-        41","district_number":"41"}},"school_districts":{"unified":{"name":"Pasadena
-        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"PST","utc_offset":-8,"observes_dst":true}}}]}'
-    http_version: 
-  recorded_at: Fri, 16 Feb 2018 17:35:13 GMT
-recorded_with: VCR 4.0.0
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"60","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"60
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
+        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"68","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"68
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145373,"lng":-118.151925},"accuracy":0.99,"accuracy_type":"rooftop","source":"Los
+        Angeles","fields":{"congressional_districts":[{"name":"Congressional District
+        28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"1","predirectional":"N","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"N DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91103","country":"US"},"formatted_address":"1
+        N DE Lacey Ave, Pasadena, CA 91103","location":{"lat":34.145759,"lng":-118.15223},"accuracy":0.98,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"1","predirectional":"S","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"S DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"1
+        S DE Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145759,"lng":-118.15223},"accuracy":0.98,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"22","predirectional":"S","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"S DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"22
+        S DE Lacey Ave, Pasadena, CA 91105","location":{"lat":34.145407,"lng":-118.152227},"accuracy":0.97,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"25","predirectional":"N","street":"DE
+        Lacey","suffix":"Ave","formatted_street":"N DE Lacey Ave","city":"Pasadena","county":"Los
+        Angeles County","state":"CA","zip":"91103","country":"US"},"formatted_address":"25
+        N DE Lacey Ave, Pasadena, CA 91103","location":{"lat":34.146409,"lng":-118.152234},"accuracy":0.96,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"85","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"85
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145759,"lng":-118.15223},"accuracy":0.47,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"1","street":"Fraser","suffix":"Aly","formatted_street":"Fraser
+        Aly","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"1
+        Fraser Aly, Pasadena, CA 91105","location":{"lat":34.145407,"lng":-118.152227},"accuracy":0.46,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"43","predirectional":"W","street":"Colorado","suffix":"Blvd","formatted_street":"W
+        Colorado Blvd","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91105","country":"US"},"formatted_address":"43
+        W Colorado Blvd, Pasadena, CA 91105","location":{"lat":34.145766,"lng":-118.15141},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"100","street":"Christiansen","suffix":"Aly","formatted_street":"Christiansen
+        Aly","city":"Pasadena","county":"Los Angeles County","state":"CA","zip":"91103","country":"US"},"formatted_address":"100
+        Christiansen Aly, Pasadena, CA 91103","location":{"lat":34.146409,"lng":-118.152234},"accuracy":0.45,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 28","district_number":28,"ocd_id":"ocd-division\/country:us\/state:ca\/cd:28","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Assembly
+        District 41","district_number":"41","ocd_id":"ocd-division\/country:us\/state:ca\/sldl:41","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"State
+        Senate District 25","district_number":"25","ocd_id":"ocd-division\/country:us\/state:ca\/sldu:25","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Pasadena
+        Unified School District","lea_code":"0629940","grade_low":"KG","grade_high":"12"}},"timezone":{"name":"America\/Los_Angeles","utc_offset":-8,"observes_dst":true,"abbreviation":"PST","source":"\u00a9
+        OpenStreetMap contributors"}}}]}'
+  recorded_at: Tue, 05 Jul 2022 22:21:47 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/reverse_with_fields_no_house_info.yml
+++ b/spec/vcr_cassettes/reverse_with_fields_no_house_info.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.geocod.io/v1/reverse?api_key=secret_api_key&fields=cd,stateleg,school,timezone&q=41.25,-96.00
+    uri: http://api.geocod.io/v1.7/reverse?api_key=secret_api_key&fields=cd118,stateleg-next,school,timezone&q=41.25,-96.00
     body:
       encoding: US-ASCII
       string: ''
@@ -18,45 +18,121 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.10.2
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Cache-Control:
-      - no-cache
+      - no-cache, private
       Date:
-      - Fri, 28 Jul 2017 19:34:00 GMT
-      Request-Handler:
-      - api19
+      - Tue, 05 Jul 2022 22:21:46 GMT
+      X-Billable-Lookups-Count:
+      - '1'
+      X-Billable-Fields-Count:
+      - '4'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
       - GET, POST
       Access-Control-Allow-Headers:
-      - Content-Type
+      - Content-Type, User-Agent
+      Access-Control-Expose-Headers:
+      - Request-Handler
+      Request-Handler:
+      - api228
+      Server:
+      - Unicorns with magic wands (https://www.geocod.io)
+      X-Request-Id:
+      - 6167D31F:FE00_05A15419:0050_62C4B97A_54511:3D82
+      Connection:
+      - close
     body:
       encoding: UTF-8
-      string: '{"results":[{"address_components":{"number":"5599","street":"Mayberry","suffix":"St","formatted_street":"Mayberry
-        St","city":"Omaha","county":"Douglas County","state":"NE","zip":"68106","country":"US"},"formatted_address":"5599
-        Mayberry St, Omaha, NE 68106","location":{"lat":41.250585,"lng":-95.997945},"accuracy":1,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
-        dataset from the US Census Bureau","fields":{"congressional_district":{"name":"Congressional
-        District 2","district_number":2,"congress_number":"115th","congress_years":"2017-2019"},"state_legislative_districts":{"senate":{"name":"State
-        Senate District 9","district_number":"9"}},"school_districts":{"unified":{"name":"Omaha
-        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"CST","utc_offset":-6,"observes_dst":true}}},{"address_components":{"number":"975","predirectional":"S","street":"57th","suffix":"St","formatted_street":"S
+      string: '{"results":[{"address_components":{"number":"5548","street":"Mason","suffix":"St","formatted_street":"Mason
+        St","city":"Omaha","county":"Douglas County","state":"NE","zip":"68106","country":"US"},"formatted_address":"5548
+        Mason St, Omaha, NE 68106","location":{"lat":41.24989,"lng":-96.00003},"accuracy":1,"accuracy_type":"rooftop","source":"Omaha","fields":{"congressional_districts":[{"name":"Congressional
+        District 2","district_number":2,"ocd_id":"ocd-division\/country:us\/state:ne\/cd:2","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldl:9","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldu:9","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Omaha
+        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"America\/Chicago","utc_offset":-6,"observes_dst":true,"abbreviation":"CST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"5548","street":"Mason","suffix":"St","formatted_street":"Mason
+        St","city":"Omaha","county":"Douglas County","state":"NE","zip":"68106","country":"US"},"formatted_address":"5548
+        Mason St, Omaha, NE 68106","location":{"lat":41.249883,"lng":-96.000022},"accuracy":1,"accuracy_type":"rooftop","source":"Statewide
+        NE","fields":{"congressional_districts":[{"name":"Congressional District 2","district_number":2,"ocd_id":"ocd-division\/country:us\/state:ne\/cd:2","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldl:9","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldu:9","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Omaha
+        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"America\/Chicago","utc_offset":-6,"observes_dst":true,"abbreviation":"CST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"5544","street":"Mason","suffix":"St","formatted_street":"Mason
+        St","city":"Omaha","county":"Douglas County","state":"NE","zip":"68106","country":"US"},"formatted_address":"5544
+        Mason St, Omaha, NE 68106","location":{"lat":41.249894,"lng":-95.999881},"accuracy":1,"accuracy_type":"rooftop","source":"Douglas","fields":{"congressional_districts":[{"name":"Congressional
+        District 2","district_number":2,"ocd_id":"ocd-division\/country:us\/state:ne\/cd:2","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldl:9","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldu:9","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Omaha
+        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"America\/Chicago","utc_offset":-6,"observes_dst":true,"abbreviation":"CST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"975","predirectional":"S","street":"57th","suffix":"St","formatted_street":"S
         57th St","city":"Omaha","county":"Douglas County","state":"NE","zip":"68106","country":"US"},"formatted_address":"975
-        S 57th St, Omaha, NE 68106","location":{"lat":41.250211,"lng":-96.001138},"accuracy":0.51,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
-        dataset from the US Census Bureau","fields":{"congressional_district":{"name":"Congressional
-        District 2","district_number":2,"congress_number":"115th","congress_years":"2017-2019"},"state_legislative_districts":{"senate":{"name":"State
-        Senate District 9","district_number":"9"}},"school_districts":{"unified":{"name":"Omaha
-        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"CST","utc_offset":-6,"observes_dst":true}}},{"address_components":{"number":"5700","street":"Mason","suffix":"St","formatted_street":"Mason
+        S 57th St, Omaha, NE 68106","location":{"lat":41.250211,"lng":-96.001138},"accuracy":0.44,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 2","district_number":2,"ocd_id":"ocd-division\/country:us\/state:ne\/cd:2","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldl:9","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldu:9","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Omaha
+        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"America\/Chicago","utc_offset":-6,"observes_dst":true,"abbreviation":"CST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"5700","street":"Mason","suffix":"St","formatted_street":"Mason
         St","city":"Omaha","county":"Douglas County","state":"NE","zip":"68106","country":"US"},"formatted_address":"5700
-        Mason St, Omaha, NE 68106","location":{"lat":41.250211,"lng":-96.001138},"accuracy":0.5,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
-        dataset from the US Census Bureau","fields":{"congressional_district":{"name":"Congressional
-        District 2","district_number":2,"congress_number":"115th","congress_years":"2017-2019"},"state_legislative_districts":{"senate":{"name":"State
-        Senate District 9","district_number":"9"}},"school_districts":{"unified":{"name":"Omaha
-        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"CST","utc_offset":-6,"observes_dst":true}}}]}'
-    http_version: 
-  recorded_at: Fri, 28 Jul 2017 19:34:00 GMT
-recorded_with: VCR 3.0.3
+        Mason St, Omaha, NE 68106","location":{"lat":41.250211,"lng":-96.001138},"accuracy":0.44,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 2","district_number":2,"ocd_id":"ocd-division\/country:us\/state:ne\/cd:2","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldl:9","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldu:9","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Omaha
+        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"America\/Chicago","utc_offset":-6,"observes_dst":true,"abbreviation":"CST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"1001","predirectional":"S","street":"57th","suffix":"St","formatted_street":"S
+        57th St","city":"Omaha","county":"Douglas County","state":"NE","zip":"68106","country":"US"},"formatted_address":"1001
+        S 57th St, Omaha, NE 68106","location":{"lat":41.249669,"lng":-96.001137},"accuracy":0.44,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 2","district_number":2,"ocd_id":"ocd-division\/country:us\/state:ne\/cd:2","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldl:9","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldu:9","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Omaha
+        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"America\/Chicago","utc_offset":-6,"observes_dst":true,"abbreviation":"CST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"1021","predirectional":"S","street":"57th","suffix":"St","formatted_street":"S
+        57th St","city":"Omaha","county":"Douglas County","state":"NE","zip":"68106","country":"US"},"formatted_address":"1021
+        S 57th St, Omaha, NE 68106","location":{"lat":41.249486,"lng":-96.001138},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 2","district_number":2,"ocd_id":"ocd-division\/country:us\/state:ne\/cd:2","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldl:9","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldu:9","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Omaha
+        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"America\/Chicago","utc_offset":-6,"observes_dst":true,"abbreviation":"CST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"5700","street":"Rees","suffix":"St","formatted_street":"Rees
+        St","city":"Omaha","county":"Douglas County","state":"NE","zip":"68106","country":"US"},"formatted_address":"5700
+        Rees St, Omaha, NE 68106","location":{"lat":41.249486,"lng":-96.001138},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 2","district_number":2,"ocd_id":"ocd-division\/country:us\/state:ne\/cd:2","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldl:9","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldu:9","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Omaha
+        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"America\/Chicago","utc_offset":-6,"observes_dst":true,"abbreviation":"CST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"962","predirectional":"S","street":"57th","suffix":"St","formatted_street":"S
+        57th St","city":"Omaha","county":"Douglas County","state":"NE","zip":"68106","country":"US"},"formatted_address":"962
+        S 57th St, Omaha, NE 68106","location":{"lat":41.250572,"lng":-96.001137},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 2","district_number":2,"ocd_id":"ocd-division\/country:us\/state:ne\/cd:2","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldl:9","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldu:9","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Omaha
+        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"America\/Chicago","utc_offset":-6,"observes_dst":true,"abbreviation":"CST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"931","predirectional":"S","street":"57th","suffix":"St","formatted_street":"S
+        57th St","city":"Omaha","county":"Douglas County","state":"NE","zip":"68106","country":"US"},"formatted_address":"931
+        S 57th St, Omaha, NE 68106","location":{"lat":41.250914,"lng":-96.001142},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 2","district_number":2,"ocd_id":"ocd-division\/country:us\/state:ne\/cd:2","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldl:9","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldu:9","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Omaha
+        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"America\/Chicago","utc_offset":-6,"observes_dst":true,"abbreviation":"CST","source":"\u00a9
+        OpenStreetMap contributors"}}},{"address_components":{"number":"5700","street":"Mayberry","suffix":"St","formatted_street":"Mayberry
+        St","city":"Omaha","county":"Douglas County","state":"NE","zip":"68106","country":"US"},"formatted_address":"5700
+        Mayberry St, Omaha, NE 68106","location":{"lat":41.250914,"lng":-96.001142},"accuracy":0.43,"accuracy_type":"nearest_street","source":"TIGER\/Line\u00ae
+        dataset from the US Census Bureau","fields":{"congressional_districts":[{"name":"Congressional
+        District 2","district_number":2,"ocd_id":"ocd-division\/country:us\/state:ne\/cd:2","congress_number":"118th","congress_years":"2023-2025","proportion":1}],"state_legislative_districts":{"house":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldl:9","is_upcoming_state_legislative_district":true,"proportion":1}],"senate":[{"name":"Legislative
+        District 9","district_number":"9","ocd_id":"ocd-division\/country:us\/state:ne\/sldu:9","is_upcoming_state_legislative_district":true,"proportion":1}]},"school_districts":{"unified":{"name":"Omaha
+        Public Schools","lea_code":"3174820","grade_low":"PK","grade_high":"12"}},"timezone":{"name":"America\/Chicago","utc_offset":-6,"observes_dst":true,"abbreviation":"CST","source":"\u00a9
+        OpenStreetMap contributors"}}}]}'
+  recorded_at: Tue, 05 Jul 2022 22:21:46 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
- Add support to Geocodio API v1.7
- Update VCR test data with fresh data(July 2022) and all rspec suite
- Implemented most recent fields: `cd118`, `stateleg-next`, `provriding` and `riding`
- Addressed `house` and `senate` coming as an array in Geocodio v1.7
- Add Canadian electoral district support
- Add OCD ID to US and Canadian electoral districts
- Bump gem version to `4.0.0`
- Updated documentation with these changes
- Handle `current_legislators` as optional because is not coming from Geocodio v1.7, `cd` in the field parameter still works. 